### PR TITLE
Accelerate and fix docs

### DIFF
--- a/docs/src/exemples/turing.md
+++ b/docs/src/exemples/turing.md
@@ -23,7 +23,7 @@ true_θ₁ = 1
 true_θ₂ = 3
 true_θ₃ = 2
 D = SklarDist(ClaytonCopula(3,true_θ), (Exponential(true_θ₁), Pareto(true_θ₂), Exponential(true_θ₃)))
-draws = rand(D, 5_000)
+draws = rand(D, 500)
 
 @model function copula(X)
     # Priors
@@ -44,7 +44,7 @@ draws = rand(D, 5_000)
 end
 
 sampler = NUTS() # MH() works too
-chain = sample(copula(draws), sampler, MCMCThreads(), 1_000, 4)
+chain = sample(copula(draws), sampler, MCMCThreads(), 100, 4)
 plot(chain)
 ```
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -109,8 +109,3 @@ If you want to contribute to the package, found a bug in it or simply want to ch
   url          = {https://doi.org/10.5281/zenodo.6652672}
 }
 ```
-
-
-```@docs
-Copulas
-```


### PR DESCRIPTION
Docs rendering was using too much ressources, so we lowered the expected numebr of sampels of the turing.jl example. 