### PR TITLE
fix typo in formula

### DIFF
--- a/docs/src/archimedean/generalities.md
+++ b/docs/src/archimedean/generalities.md
@@ -87,10 +87,10 @@ This transformation is implemented through one method in the Generator interface
 To put it in a nutshell, for ``\phi`` a ``d``-monotone archimedean generator, the inverse Williamson-d-transform of ``\\phi`` is the cumulative distribution function ``F`` of a non-negative random variable ``R``, defined by : 
 
 ```math
-F(x) = 𝒲_{d}^{-1}(\\phi)(x) = 1 - \\frac{(-x)^{d-1} \\phi_+^{(d-1)}(x)}{k!} - \\sum_{k=0}^{d-2} \\frac{(-x)^k \\phi^{(k)}(x)}{k!}
+F(x) = 𝒲_{d}^{-1}(\phi)(x) = 1 - \frac{(-x)^{d-1} \phi_+^{(d-1)}(x)}{k!} - \sum_{k=0}^{d-2} \frac{(-x)^k \phi^{(k)}(x)}{k!}
 ```
 
-The [WilliamsonTransforms.jl](https://github.com/lrnv/WilliamsonTransforms.jl) package implements this transfromation (and its inverse, the Williamson d-transfrom) in all generality. It returns this cumulative distribution function in the form of the corresponding random variable `<:Distributions.ContinuousUnivariateDistribution` from `Distributions.jl`. You may then compute : 
+The [WilliamsonTransforms.jl](https://github.com/lrnv/WilliamsonTransforms.jl) package implements this transformation (and its inverse, the Williamson d-transfrom) in all generality. It returns this cumulative distribution function in the form of the corresponding random variable `<:Distributions.ContinuousUnivariateDistribution` from `Distributions.jl`. You may then compute : 
 * The cdf via `Distributions.cdf`
 * The pdf via `Distributions.pdf` and the logpdf via `Distributions.logpdf`
 * Samples from the distribution via `rand(X,n)`

--- a/src/EllipticalCopula.jl
+++ b/src/EllipticalCopula.jl
@@ -4,15 +4,15 @@
 This is an abstract type. It implements an interface for all Elliptical copulas. We construct internally elliptical copulas using the sklar's theorem, by considering the copula ``C`` to be defined as : 
 
 ```math
-C = F `\\circ (F_1^{-1},...,F_d^{-1}),
+C = F \\circ (F_1^{-1},...,F_d^{-1}),
 ```
 
-where ``F`` and ``F_1,...,F_d`` are respectively the multivariate distribution function of some elliptical random vector and the univaraite distribution function of its marginals.  For a type `MyCop <: EllipitcalCopula`, it is necessary to implement the following methods: 
+where ``F`` and ``F_1,...,F_d`` are respectively the multivariate distribution function of some elliptical random vector and the univariate distribution function of its marginals.  For a type `MyCop <: EllipitcalCopula`, it is necessary to implement the following methods: 
 
-- `N(::Type{MyCOp})`, returning the constructor of the elliptical random vector from its corelation matrix. For example, `N(GaussianCopula)` simply returns `MvNormal` from `Distributions.jl`.
-- `U(::Type{MyCOp})`, returning the constructor for the univariate marginal, usually in standardized form. For exemple, `U(GaussianCopula)` returns `Normal` from `Distributions.jl`.
+- `N(::Type{MyCOp})`, returning the constructor of the elliptical random vector from its correlation matrix. For example, `N(GaussianCopula)` simply returns `MvNormal` from `Distributions.jl`.
+- `U(::Type{MyCOp})`, returning the constructor for the univariate marginal, usually in standardized form. For example, `U(GaussianCopula)` returns `Normal` from `Distributions.jl`.
 
-From these two functions, the abstract type provide a fully functional copula. 
+From these two functions, the abstract type provides a fully functional copula. 
 
 # Details 
 


### PR DESCRIPTION
the backtick is redundant
![image](https://github.com/lrnv/Copulas.jl/assets/13688320/1f88919b-bbb8-4f3e-aa84-19be2bb888a8)

also fix some typo in the docstring