### PR TITLE
Remove overflows for bivariate gumbel density

### DIFF
--- a/src/ArchimedeanCopula.jl
+++ b/src/ArchimedeanCopula.jl
@@ -205,20 +205,3 @@ function Distributions._rand!(rng::Distributions.AbstractRNG, ::ArchimedeanCopul
     return A
 end
 
-# The Gumbel copula needs a specific bivariate method to handle large parameters. 
-function _cdf(C::ArchimedeanCopula{2,G}, u) where {G<:GumbelGenerator}
-    θ = C.G.θ
-    x₁, x₂ = -log(u[1]), -log(u[2])
-    lx₁, lx₂ = log(x₁), log(x₂)
-    return 1 - LogExpFunctions.cexpexp(LogExpFunctions.logaddexp(θ * lx₁, θ * lx₂) / θ)
-end
-function Distributions._logpdf(C::ArchimedeanCopula{2,G}, u) where {G<:GumbelGenerator}
-    !all(0 .<= u .<= 1) && return eltype(u)(-Inf) # if not in range return -Inf
-
-    θ = C.G.θ
-    x₁, x₂ = -log(u[1]), -log(u[2])
-    lx₁, lx₂ = log(x₁), log(x₂)
-    A = LogExpFunctions.logaddexp(θ * lx₁, θ * lx₂)
-    B = exp(A/θ)
-    return - B + x₁ + x₂ + (θ-1) * (lx₁ + lx₂) + A/θ - 2A + log(B + θ - 1)
-end

--- a/src/ArchimedeanCopula.jl
+++ b/src/ArchimedeanCopula.jl
@@ -210,7 +210,7 @@ function _cdf(C::ArchimedeanCopula{2,G}, u) where {G<:GumbelGenerator}
     θ = C.G.θ
     x₁, x₂ = -log(u[1]), -log(u[2])
     lx₁, lx₂ = log(x₁), log(x₂)
-    return 1 - LogExpFunctions.cexpexp(1/θ * LogExpFunctions.logaddexp(θ * lx₁, θ * lx₂))
+    return 1 - LogExpFunctions.cexpexp(LogExpFunctions.logaddexp(θ * lx₁, θ * lx₂) / θ)
 end
 function Distributions._logpdf(C::ArchimedeanCopula{2,G}, u) where {G<:GumbelGenerator}
     !all(0 .<= u .<= 1) && return eltype(u)(-Inf) # if not in range return -Inf
@@ -218,12 +218,7 @@ function Distributions._logpdf(C::ArchimedeanCopula{2,G}, u) where {G<:GumbelGen
     θ = C.G.θ
     x₁, x₂ = -log(u[1]), -log(u[2])
     lx₁, lx₂ = log(x₁), log(x₂)
-
-    y = (x₁ + x₂) + (θ-1) * (lx₁ + lx₂)
-    y == Inf && return Inf # shortcut
-
-    a = LogExpFunctions.logaddexp(θ * lx₁, θ * lx₂)
-    b = a/θ
-    c = a - log(θ-1)
-    return y + b + LogExpFunctions.log1pexp(c) - a - c - exp(b) 
+    A = LogExpFunctions.logaddexp(θ * lx₁, θ * lx₂)
+    B = exp(A/θ)
+    return - B + x₁ + x₂ + (θ-1) * (lx₁ + lx₂) + A/θ - 2A + log(B + θ - 1)
 end

--- a/src/ArchimedeanCopula.jl
+++ b/src/ArchimedeanCopula.jl
@@ -205,3 +205,25 @@ function Distributions._rand!(rng::Distributions.AbstractRNG, ::ArchimedeanCopul
     return A
 end
 
+# Some archimedean copulas need specific bivariate methods: 
+function _cdf(C::ArchimedeanCopula{2,G}, u) where {G<:GumbelGenerator}
+    θ = C.G.θ
+    x₁, x₂ = -log(u[1]), -log(u[2])
+    lx₁, lx₂ = log(x₁), log(x₂)
+    return 1 - LogExpFunctions.cexpexp(1/θ * LogExpFunctions.logaddexp(θ * lx₁, θ * lx₂))
+end
+function Distributions._logpdf(C::ArchimedeanCopula{2,G}, u) where {G<:GumbelGenerator}
+    !all(0 .<= u .<= 1) && return eltype(u)(-Inf) # if not in range return -Inf
+
+    θ = C.G.θ
+    x₁, x₂ = -log(u[1]), -log(u[2])
+    lx₁, lx₂ = log(x₁), log(x₂)
+
+    y = (x₁ + x₂) + (θ-1) * (lx₁ + lx₂)
+    y == Inf && return Inf # shortcut
+
+    a = LogExpFunctions.logaddexp(θ * lx₁, θ * lx₂)
+    b = a/θ
+    c = a - log(θ-1)
+    return y + b + LogExpFunctions.log1pexp(c) - a - c - exp(b) 
+end

--- a/src/ArchimedeanCopula.jl
+++ b/src/ArchimedeanCopula.jl
@@ -205,7 +205,7 @@ function Distributions._rand!(rng::Distributions.AbstractRNG, ::ArchimedeanCopul
     return A
 end
 
-# Some archimedean copulas need specific bivariate methods: 
+# The Gumbel copula needs a specific bivariate method to handle large parameters. 
 function _cdf(C::ArchimedeanCopula{2,G}, u) where {G<:GumbelGenerator}
     θ = C.G.θ
     x₁, x₂ = -log(u[1]), -log(u[2])

--- a/src/BivariateArchimedeanMethods.jl
+++ b/src/BivariateArchimedeanMethods.jl
@@ -1,0 +1,17 @@
+# The Gumbel copula needs a specific bivariate method to handle large parameters. 
+function _cdf(C::ArchimedeanCopula{2,G}, u) where {G<:GumbelGenerator}
+    θ = C.G.θ
+    x₁, x₂ = -log(u[1]), -log(u[2])
+    lx₁, lx₂ = log(x₁), log(x₂)
+    return 1 - LogExpFunctions.cexpexp(LogExpFunctions.logaddexp(θ * lx₁, θ * lx₂) / θ)
+end
+function Distributions._logpdf(C::ArchimedeanCopula{2,G}, u) where {G<:GumbelGenerator}
+    !all(0 .<= u .<= 1) && return eltype(u)(-Inf) # if not in range return -Inf
+
+    θ = C.G.θ
+    x₁, x₂ = -log(u[1]), -log(u[2])
+    lx₁, lx₂ = log(x₁), log(x₂)
+    A = LogExpFunctions.logaddexp(θ * lx₁, θ * lx₂)
+    B = exp(A/θ)
+    return - B + x₁ + x₂ + (θ-1) * (lx₁ + lx₂) + A/θ - 2A + log(B + θ - 1)
+end

--- a/src/Copulas.jl
+++ b/src/Copulas.jl
@@ -70,6 +70,7 @@ module Copulas
     
     # Archimedean copulas
     include("ArchimedeanCopula.jl")
+    include("BivariateArchimedeanMethods.jl")
     export ArchimedeanCopula,
            IndependentCopula,
            MCopula,

--- a/src/Generator/UnivariateGenerator/GumbelGenerator.jl
+++ b/src/Generator/UnivariateGenerator/GumbelGenerator.jl
@@ -60,25 +60,3 @@ function τ⁻¹(::Type{T},τ) where T<:GumbelGenerator
     end
 end
 williamson_dist(G::GumbelGenerator, d) = WilliamsonFromFrailty(AlphaStable(α = 1/G.θ, β = 1,scale = cos(π/(2G.θ))^G.θ, location = (G.θ == 1 ? 1 : 0)), d)
-
-function _cdf(C::ArchimedeanCopula{2,G}, u) where {G<:GumbelGenerator}
-    θ = C.G.θ
-    x₁, x₂ = -log(u[1]), -log(u[2])
-    lx₁, lx₂ = log(x₁), log(x₂)
-    return 1 - LogExpFunctions.cexpexp(1/θ * LogExpFunctions.logaddexp(θ * lx₁, θ * lx₂))
-end
-function Distributions._logpdf(C::ArchimedeanCopula{2,G}, u) where {G<:GumbelGenerator}
-    !all(0 .<= u .<= 1) && return eltype(u)(-Inf) # if not in range return -Inf
-
-    θ = C.G.θ
-    x₁, x₂ = -log(u[1]), -log(u[2])
-    lx₁, lx₂ = log(x₁), log(x₂)
-
-    y = (x₁ + x₂) + (θ-1) * (lx₁ + lx₂)
-    y == Inf && return Inf # shortcut
-
-    a = LogExpFunctions.logaddexp(θ * lx₁, θ * lx₂)
-    b = a/θ
-    c = a - log(θ-1)
-    return y + b + LogExpFunctions.log1pexp(c) - a - c - exp(b) 
-end

--- a/src/Generator/UnivariateGenerator/GumbelGenerator.jl
+++ b/src/Generator/UnivariateGenerator/GumbelGenerator.jl
@@ -61,7 +61,12 @@ function τ⁻¹(::Type{T},τ) where T<:GumbelGenerator
 end
 williamson_dist(G::GumbelGenerator, d) = WilliamsonFromFrailty(AlphaStable(α = 1/G.θ, β = 1,scale = cos(π/(2G.θ))^G.θ, location = (G.θ == 1 ? 1 : 0)), d)
 
-
+function Distributions._cdf(C::ArchimedeanCopula{2,G}, u) where {G<:GumbelGenerator}
+    θ = C.G.θ
+    x₁, x₂ = -log(u[1]), -log(u[2])
+    lx₁, lx₂ = log(x₁), log(x₂)
+    return exp( - exp(1/θ * LogExpFunctions.logaddexp(θ * lx₁, θ * lx₂)))
+end
 function Distributions._logpdf(C::ArchimedeanCopula{2,G}, u) where {G<:GumbelGenerator}
     !all(0 .<= u .<= 1) && return eltype(u)(-Inf) # if not in range return -Inf
 

--- a/src/Generator/UnivariateGenerator/GumbelGenerator.jl
+++ b/src/Generator/UnivariateGenerator/GumbelGenerator.jl
@@ -61,11 +61,11 @@ function τ⁻¹(::Type{T},τ) where T<:GumbelGenerator
 end
 williamson_dist(G::GumbelGenerator, d) = WilliamsonFromFrailty(AlphaStable(α = 1/G.θ, β = 1,scale = cos(π/(2G.θ))^G.θ, location = (G.θ == 1 ? 1 : 0)), d)
 
-function Distributions._cdf(C::ArchimedeanCopula{2,G}, u) where {G<:GumbelGenerator}
+function _cdf(C::ArchimedeanCopula{2,G}, u) where {G<:GumbelGenerator}
     θ = C.G.θ
     x₁, x₂ = -log(u[1]), -log(u[2])
     lx₁, lx₂ = log(x₁), log(x₂)
-    return exp( - exp(1/θ * LogExpFunctions.logaddexp(θ * lx₁, θ * lx₂)))
+    return 1 - LogExpFunctions.cexpexp(1/θ * LogExpFunctions.logaddexp(θ * lx₁, θ * lx₂))
 end
 function Distributions._logpdf(C::ArchimedeanCopula{2,G}, u) where {G<:GumbelGenerator}
     !all(0 .<= u .<= 1) && return eltype(u)(-Inf) # if not in range return -Inf

--- a/src/Generator/UnivariateGenerator/GumbelGenerator.jl
+++ b/src/Generator/UnivariateGenerator/GumbelGenerator.jl
@@ -39,7 +39,12 @@ end
 max_monotony(G::GumbelGenerator) = Inf
 ϕ(  G::GumbelGenerator, t) = exp(-t^(1/G.θ))
 ϕ⁻¹(G::GumbelGenerator, t) = (-log(t))^G.θ
-# ϕ⁽¹⁾(G::GumbelGenerator, t) =  First derivative of ϕ
+function ϕ⁽¹⁾(G::GumbelGenerator, t)
+    # first derivative of ϕ
+    a = 1/G.θ
+    tam1 = t^(a-1)
+    return - a * tam1 * exp(-tam1*t)
+end
 # ϕ⁽ᵏ⁾(G::GumbelGenerator, k, t) = kth derivative of ϕ
 τ(G::GumbelGenerator) = ifelse(isfinite(G.θ), (G.θ-1)/G.θ, 1)
 function τ⁻¹(::Type{T},τ) where T<:GumbelGenerator 
@@ -55,3 +60,20 @@ function τ⁻¹(::Type{T},τ) where T<:GumbelGenerator
     end
 end
 williamson_dist(G::GumbelGenerator, d) = WilliamsonFromFrailty(AlphaStable(α = 1/G.θ, β = 1,scale = cos(π/(2G.θ))^G.θ, location = (G.θ == 1 ? 1 : 0)), d)
+
+
+function Distributions._logpdf(C::ArchimedeanCopula{2,G}, u) where {G<:GumbelGenerator}
+    !all(0 .<= u .<= 1) && return eltype(u)(-Inf) # if not in range return -Inf
+
+    θ = C.G.θ
+    x₁, x₂ = -log(u[1]), -log(u[2])
+    lx₁, lx₂ = log(x₁), log(x₂)
+
+    y = (x₁ + x₂) + (θ-1) * (lx₁ + lx₂)
+    y == Inf && return Inf # shortcut
+
+    a = LogExpFunctions.logaddexp(θ * lx₁, θ * lx₂)
+    b = a/θ
+    c = a - log(θ-1)
+    return y + b + LogExpFunctions.log1pexp(c) - a - c - exp(b) 
+end

--- a/test/test_extreme_gumbel_density.jl
+++ b/test/test_extreme_gumbel_density.jl
@@ -1,0 +1,12 @@
+@testitem "Extreme gumbel density test" begin
+    using Distributions
+    G = GumbelCopula(2, 244.3966206319112)
+    u = [0.969034207932297,0.9638122014293545]
+    den = pdf(G, u)
+    @test true
+
+    G = GumbelCopula(2, 344.3966206319112)
+    u = [0.969034207932297,0.9638122014293545]
+    den = pdf(G, u)
+    @test true
+end

--- a/test/test_extreme_gumbel_density.jl
+++ b/test/test_extreme_gumbel_density.jl
@@ -5,7 +5,7 @@
     den = pdf(G, u)
     @test true
 
-    G = GumbelCopula(2, 344.3966206319112)
+    G = GumbelCopula(2, 1544.3966206319112)
     u = [0.969034207932297,0.9638122014293545]
     den = pdf(G, u)
     @test true


### PR DESCRIPTION
Fixes #215

@Santymax98 please tell me what you think about this. Basically I rewrote the bivariate gumbel density to leverage the `logaddexp` function that compute without mistake `log(exp(a)+exp(b))`, whic is in the code of thebivariate gumbel density. 

I guess that the same thing could be done for multivariate cases.. @Santymax98 Do you by chance know a reference where the formula for the multivariate gumbel density is written ? 

PS: I am not sure the values yielded are the right one... It looks like i have made a mistake while deriving it...