### PR TITLE
Formalize Kendall Tau and Spearman Rho Interfaces

### DIFF
--- a/docs/src/assets/references.bib
+++ b/docs/src/assets/references.bib
@@ -846,3 +846,22 @@
   year={2014},
   publisher={Springer}
 }
+
+@article{fang2002meta,
+  title={The meta-elliptical distributions with given marginals},
+  author={Fang, Hong-Bin and Fang, Kai-Tai and Kotz, Samuel},
+  journal={Journal of multivariate analysis},
+  volume={82},
+  number={1},
+  pages={1--16},
+  year={2002},
+  publisher={Elsevier}
+}
+@incollection{lindskog2003kendall,
+  title={Kendall’s tau for elliptical distributions},
+  author={Lindskog, Filip and McNeil, Alexander and Schmock, Uwe},
+  booktitle={Credit risk: Measurement, evaluation and management},
+  pages={149--156},
+  year={2003},
+  publisher={Springer}
+}

--- a/docs/src/dependence_measures.md
+++ b/docs/src/dependence_measures.md
@@ -4,21 +4,15 @@
 Although the copula is an object that summarizes completely the dependence structure of any random vector, it is an infinite dimensional object and the interpretation of its properties can be difficult when the dimension gets high. Therefore, the literature has come up with some quantification of the dependence structure that might be used as univariate summaries, of course imperfect, of certain properties of the copula at hand. 
 
 
-!!! note "Unfinished work"
-    Unfortunately these dependence measures are not yet well-specified in the package and their implementation is experimental for the moment. These functions might change in the future, in particular see https://github.com/lrnv/Copulas.jl/issues/134 for future improvements. 
+## Multivariate Kendall's Tau 
 
-
-## Kendall's Tau 
-
-> **Definition (Kendall' τ):** For a copula $C$ with a density $c$, Kendall's τ is defined as: 
+> **Definition (Kendall' τ):** For a copula $C$ with a density $c$, **whatever its dimension $d$**, its Kendall's τ is defined as: 
 > 
 >$$\tau = 4 \int C(\bm u) \, c(\bm u) \;d\bm u -1$$
 
 Kendall's tau can be obtained through `τ(C::Copula)`. Its value only depends on the dependence structure and not the marginals. 
 
-!!! warn "Multivariate case"
-    There exists several multivariate extensions of Kendall's tau. The one implemented here is the one we just defined what ever the dimension $d$, be careful as the normalization might differ from other places in the literature.
-
+In the literature however, for multivariate copuals, the matrix of bivariate kendall taus is sometimes used. In this package it can be obtained through the `StatsBase.corkendall(C::Copula)` interface.
 
 
 ## Spearman's Rho 

--- a/docs/src/dependence_measures.md
+++ b/docs/src/dependence_measures.md
@@ -3,7 +3,7 @@
 
 Although Copulas summarize completely the dependence structure of corresponding random vector, it is an infinite dimensional object and the interpretation of its properties can be difficult when the dimension gets high. Therefore, the literature has come up with some quantification of the dependence structure that might be used as univariate summaries, of course imperfect, of certain properties of the copula at hand. 
 
-## Multivariate and Bivariate Kendall's Tau and Spearman rhos. 
+## Kendall's τ and Spearman's ρ: bivariate and multivariate cases
 
 > **Definition (Kendall' τ):** For a copula $C$ with a density $c$, **whatever its dimension $d$**, its Kendall's τ is defined as: 
 > 
@@ -25,6 +25,15 @@ In the literature however, for multivariate copulas, the matrices of bivariate K
 
 Many copula estimators are based on these coefficients, see e.g., [genest2011,fredricks2007,derumigny2017](@cite).
 
+A few remarks on the state of the implementation:
+
+* Bivariate elliptical cases use $\tau = asin(\rho) * 2 / \pi$ where $\rho$ is the spearman correlation, as soon as the radial part does not have atoms. See [fang2002meta](@cite) for historical credits and [lindskog2003kendall](@cite) for a good review.
+* Many Archimedean copulas have specific formulas for their Kendall tau's, but generic ones use [mcneil2009](@cite). 
+* Generic copulas use directly the upper formula. 
+* Estimation is done for some copulas wia inversion of Kendall's tau or Spearman's rho.
+
+!!! note "Spearman's rho: work in progress"
+    If most of the efficient family-specific formulas for Kendall's tau are already implemented in the package, Spearman's $\rho$'s tend to leverage the generic (slow) implementation much more. If you feel like a specific method for a certain copula is missing, do not hesitate to open an issue !
 
 ## Tail dependency
 

--- a/docs/src/dependence_measures.md
+++ b/docs/src/dependence_measures.md
@@ -4,34 +4,33 @@
 Although the copula is an object that summarizes completely the dependence structure of any random vector, it is an infinite dimensional object and the interpretation of its properties can be difficult when the dimension gets high. Therefore, the literature has come up with some quantification of the dependence structure that might be used as univariate summaries, of course imperfect, of certain properties of the copula at hand. 
 
 
-## Multivariate Kendall's Tau 
+
+## Multivariate and Bivariate Kendall's Tau and Spearman rhos. 
+
+
 
 > **Definition (Kendall' τ):** For a copula $C$ with a density $c$, **whatever its dimension $d$**, its Kendall's τ is defined as: 
 > 
 >$$\tau = 4 \int C(\bm u) \, c(\bm u) \;d\bm u -1$$
 
-Kendall's tau can be obtained through `τ(C::Copula)`. Its value only depends on the dependence structure and not the marginals. 
-
-In the literature however, for multivariate copuals, the matrix of bivariate kendall taus is sometimes used. In this package it can be obtained through the `StatsBase.corkendall(C::Copula)` interface.
-
-
-## Spearman's Rho 
-
-> **Definition (Spearman's ρ):** For a copula $C$ with a density $c$, the Spearman's ρ is defined as: 
+> **Definition (Spearman's ρ):** For a copula $C$ with a density $c$, **whatever its dimension $d$**, the Spearman's ρ is defined as: 
 >
 > $$\rho = 12 \int C(\bm u) d\bm u -3.$$
 
-Spearman's Rho can be obtained through `ρ(C::Copula)`. Its value only depends on the dependence structure and not the marginals. 
+These two dependence measures make more sense in the bivariate case than in other cases, and therefore we sometimes refer to the Kendall's matrix or the Spearman's matrix for the collection of bivariate coefficients associated to a multivariate copula. We thus provide two different interfaces, one internal through `Copulas.τ(C::Copula)` and `Copulas.ρ(C::Copula)`, providing true multivariate Kendall taus and Spearman rhos, and one implementing `StatsBase.corkendall(C::Copula)` and `StatsBase.corspearman(C::Copula)` for matrices of bivariate dependence measures. 
 
-!!! warn "Multivariate case"
-    There exists several multivariate extensions of Spearman's rho. The one implemented here is the one we just defined what ever the dimension $d$, be careful as the normalization might differ from other places in the literature.
+Thus, for a given copula `C`, its Kendall's tau can be obtained through `τ(C::Copula)` and its Spearman's Rho through `ρ(C::Copula)`. 
+
+In the literature however, for multivariate copulas, the matrices of bivariate Kendall taus and bivariate Spearman rhos are sometimes used, and this is these matrices that are obtained by `StatsBase.corkendall(data)` and `StatsBase.corspearman(data)` where `data::Matrix{n,d}` is a matrix of observations. The corresponding theoretical values for copulas in this package can be obtained through the `StatsBase.corkendall(C::Copula)` and `StatsBase.corspearman(C::Copula)` interface.
+
+
 
 !!! note "Specific values of tau and rho"
-    Kendall's $\tau$ and Spearman's $\rho$ have values between -1 and 1, and are -1 in case of complete anticomonotony and 1 in case of comonotony. Moreover, they are 0 in case of independence. This is 
-    why we say that they measure the 'strength' of the dependency.
+    Kendall's $\tau$ and Spearman's $\rho$ have values between -1 and 1, and are -1 in case of complete anticomonotony and 1 in case of comonotony. Moreover, they are 0 in case of independence. Moreover, their values only depends on the dependence structure and not the marginals. This is why we say that they measure the 'strength' of the dependency.
 
-!!! tip "More-that-bivariate cases"
-    These two dependence measures make more sense in the bivariate case than in other cases, and therefore we sometimes refer to the Kendall's matrix or the Spearman's matrix for the collection of bivariate coefficients associated to a multivariate copula. Many copula estimators are based on these coefficients, see e.g., [genest2011,fredricks2007,derumigny2017](@cite).
+
+Many copula estimators are based on these coefficients, see e.g., [genest2011,fredricks2007,derumigny2017](@cite).
+
 
 ## Tail dependency
 

--- a/docs/src/dependence_measures.md
+++ b/docs/src/dependence_measures.md
@@ -1,13 +1,9 @@
 # Measures of dependency
 
 
-Although the copula is an object that summarizes completely the dependence structure of any random vector, it is an infinite dimensional object and the interpretation of its properties can be difficult when the dimension gets high. Therefore, the literature has come up with some quantification of the dependence structure that might be used as univariate summaries, of course imperfect, of certain properties of the copula at hand. 
-
-
+Although Copulas summarize completely the dependence structure of corresponding random vector, it is an infinite dimensional object and the interpretation of its properties can be difficult when the dimension gets high. Therefore, the literature has come up with some quantification of the dependence structure that might be used as univariate summaries, of course imperfect, of certain properties of the copula at hand. 
 
 ## Multivariate and Bivariate Kendall's Tau and Spearman rhos. 
-
-
 
 > **Definition (Kendall' τ):** For a copula $C$ with a density $c$, **whatever its dimension $d$**, its Kendall's τ is defined as: 
 > 
@@ -24,10 +20,8 @@ Thus, for a given copula `C`, its Kendall's tau can be obtained through `τ(C::C
 In the literature however, for multivariate copulas, the matrices of bivariate Kendall taus and bivariate Spearman rhos are sometimes used, and this is these matrices that are obtained by `StatsBase.corkendall(data)` and `StatsBase.corspearman(data)` where `data::Matrix{n,d}` is a matrix of observations. The corresponding theoretical values for copulas in this package can be obtained through the `StatsBase.corkendall(C::Copula)` and `StatsBase.corspearman(C::Copula)` interface.
 
 
-
 !!! note "Specific values of tau and rho"
     Kendall's $\tau$ and Spearman's $\rho$ have values between -1 and 1, and are -1 in case of complete anticomonotony and 1 in case of comonotony. Moreover, they are 0 in case of independence. Moreover, their values only depends on the dependence structure and not the marginals. This is why we say that they measure the 'strength' of the dependency.
-
 
 Many copula estimators are based on these coefficients, see e.g., [genest2011,fredricks2007,derumigny2017](@cite).
 

--- a/src/Copula.jl
+++ b/src/Copula.jl
@@ -36,8 +36,18 @@ function ρ(C::Copula{d}) where d
 end
 function τ(C::Copula)
     F(x) = Distributions.cdf(C,x)
-    r = Distributions.expectation(F,C)
+    r = Distributions.expectation(F,C; nsamples=10^4)
     return 4*r-1
+end
+function StatsBase.corkendall(C::Copula{d}) where d
+    # returns the matrix of bivariate kendall taus. 
+    K = zeros(d,d)
+    for i in 1:d
+        for j in 1:d
+            K[i,j] = i==j ? 1 : τ(SubsetCopula(C::Copula{d},(i,j)))
+        end
+    end
+    return K
 end
 function measure(C::CT, u,v) where {CT<:Copula}
 

--- a/src/Copula.jl
+++ b/src/Copula.jl
@@ -49,6 +49,16 @@ function StatsBase.corkendall(C::Copula{d}) where d
     end
     return K
 end
+function StatsBase.corspearman(C::Copula{d}) where d
+    # returns the matrix of bivariate spearman rhos. 
+    K = zeros(d,d)
+    for i in 1:d
+        for j in 1:d
+            K[i,j] = i==j ? 1 : ρ(SubsetCopula(C::Copula{d},(i,j)))
+        end
+    end
+    return K
+end
 function measure(C::CT, u,v) where {CT<:Copula}
 
     # Computes the value of the cdf at each corner of the hypercube [u,v]

--- a/src/EllipticalCopulas/GaussianCopula.jl
+++ b/src/EllipticalCopulas/GaussianCopula.jl
@@ -63,3 +63,8 @@ function _cdf(C::CT,u) where {CT<:GaussianCopula}
     lb = repeat([T(-Inf)],d)
     return MvNormalCDF.mvnormcdf(μ, C.Σ, lb, x)[1]
 end
+
+# Kendall tau of bivariate gaussian: 
+# Theorem 3.1 in Fang, Fang, & Kotz, The Meta-elliptical Distributions with Given Marginals Journal of Multivariate Analysis, Elsevier, 2002, 82, 1–16 
+τ(C::GaussianCopula{2,MT}) where MT = 2*asin(C.Σ[1,2])/π 
+

--- a/src/EllipticalCopulas/TCopula.jl
+++ b/src/EllipticalCopulas/TCopula.jl
@@ -55,3 +55,7 @@ function Distributions.fit(::Type{CT},u) where {CT<:TCopula}
     df = N.df
     return TCopula(df,Σ)
 end
+
+# Kendall tau of bivariate student: 
+# Lindskog, F., McNeil, A., & Schmock, U. (2003). Kendall’s tau for elliptical distributions. In Credit risk: Measurement, evaluation and management (pp. 149-156). Heidelberg: Physica-Verlag HD.
+τ(C::TCopula{2,MT}) where MT = 2*asin(C.Σ[1,2])/π 

--- a/src/Generator/WilliamsonGenerator.jl
+++ b/src/Generator/WilliamsonGenerator.jl
@@ -55,3 +55,6 @@ function williamson_dist(G::WilliamsonGenerator, d)
     return WilliamsonTransforms.𝒲₋₁(t -> ϕ(G,t),d)
 end
 ϕ(G::WilliamsonGenerator, t) = WilliamsonTransforms.𝒲(G.X,G.d)(t)
+
+# McNeil & Neshelova 2009
+τ(G::WilliamsonGenerator) = 4*Distributions.expectation(x -> Copulas.ϕ(G,x), Copulas.williamson_dist(G,2))-1

--- a/src/MiscellaneousCopulas/EmpiricalCopula.jl
+++ b/src/MiscellaneousCopulas/EmpiricalCopula.jl
@@ -44,3 +44,4 @@ end
 function Distributions.fit(::Type{CT},u) where {CT <: EmpiricalCopula}
     return EmpiricalCopula(u)
 end
+StatsBase.corkendall(C::EmpiricalCopula) = StatsBase.corkendall(C.u)

--- a/src/SubsetCopula.jl
+++ b/src/SubsetCopula.jl
@@ -42,11 +42,10 @@ end
 # A few specialized constructors: 
 SubsetCopula(C::GaussianCopula,dims) = length(dims) == 1 ? Distributions.Uniform() : GaussianCopula(C.Σ[collect(dims),collect(dims)])
 SubsetCopula(C::TCopula{d,df,MT},dims) where {d,df,MT} = length(dims) == 1 ? Distributions.Uniform() : TCopula(df, C.Σ[collect(dims),collect(dims)])
-SubsetCopula(C::ArchimedeanCopula{d,TG},dims) where {d,TG} = length(dims) == 1 ? Distributions.Uniform() : ArchimedeanCopula(length(dims), C.G) # in particular for the independence this will work. 
+SubsetCopula(C::ArchimedeanCopula{d,TG},dims) where {d,TG} = length(dims) == 1 ? Distributions.Uniform() : ArchimedeanCopula(length(dims), C.G) # in particular for the independence this will work.
 
-# We could add a few more for performance if needed: EmpiricalCopula, others... 
-
-
+# Kendall tau of bivariate subsets, when the underlying copula is bivariate, should just be kendall tau of the underlying copula. 
+τ(C::SubsetCopula{2,CT}) where {CT<:Copula{2}} = τ(C.C)
 
 """
     subsetdims(C::Copula,dims)

--- a/src/UnivariateDistribution/WilliamsonFromFrailty.jl
+++ b/src/UnivariateDistribution/WilliamsonFromFrailty.jl
@@ -23,3 +23,5 @@ function Distributions.pdf(D::WilliamsonFromFrailty{TF,d}, x::Real) where {TF,d}
         Distributions.Erlang(d)
     )
 end
+Base.minimum(D::WilliamsonFromFrailty{TF,d}) where {TF,d} = 0
+Base.maximum(D::WilliamsonFromFrailty{TF,d}) where {TF,d} = Inf

--- a/test/kendall_tau_notnan.jl
+++ b/test/kendall_tau_notnan.jl
@@ -19,7 +19,7 @@
         InvGaussianCopula(4,0.05),
         InvGaussianCopula(3,8.),
         GaussianCopula([1 0.5; 0.5 1]),
-        # TCopula(4, [1 0.5; 0.5 1]), # this one takes a while. 
+        TCopula(4, [1 0.5; 0.5 1]),
         FGMCopula(2,1),
         MCopula(4),
         WCopula(2),
@@ -28,11 +28,11 @@
         SurvivalCopula(ClaytonCopula(2,-0.7),(1,2)),
         RafteryCopula(2, 0.2),
         RafteryCopula(3, 0.5),
+        ArchimedeanCopula(2,i𝒲(LogNormal(),2)),
         # Others ? Yes probably others too ! 
     )
 
     for C in cops
         @test !isnan(Copulas.τ(C))
     end
-    @test_broken Copulas.τ(ArchimedeanCopula(2,i𝒲(LogNormal(),2))) # not implemented. 
 end


### PR DESCRIPTION
Define `StatsBase.corkendall` as the outside interface for the matrix of bivariate kendall taus, and `Copulas.\tau` for the multivariate ones.

Also adds a few missing cases. 

Fills up the documentation with the new interface

Fixes #134