### PR TITLE
Adding empirical copulas

### DIFF
--- a/docs/src/assets/references.bib
+++ b/docs/src/assets/references.bib
@@ -992,3 +992,44 @@
   year={2014},
   publisher={Elsevier}
 }
+
+@article{segers2017empirical,
+  title={The empirical beta copula},
+  author={Segers, Johan and Sibuya, Masaaki and Tsukahara, Hideatsu},
+  journal={Journal of Multivariate Analysis},
+  volume={155},
+  pages={35--51},
+  year={2017},
+  publisher={Elsevier}
+}
+
+@article{sancetta2004bernstein,
+  title={The Bernstein copula and its applications to modeling and approximations of multivariate distributions},
+  author={Sancetta, Alessio and Satchell, Stephen},
+  journal={Econometric theory},
+  volume={20},
+  number={3},
+  pages={535--562},
+  year={2004},
+  publisher={Cambridge University Press}
+}
+
+@article{gudendorf2011nonparametric,
+  title={Nonparametric estimation of an extreme-value copula in arbitrary dimensions},
+  author={Gudendorf, Gordon and Segers, Johan},
+  journal={Journal of multivariate analysis},
+  volume={102},
+  number={1},
+  pages={37--47},
+  year={2011},
+  publisher={Elsevier}
+}
+
+@article{caperaa1997nonparametric,
+  title={A nonparametric estimation procedure for bivariate extreme value copulas},
+  author={Cap{\'e}ra{\`a}, Philippe and Foug{\`e}res, A-L and Genest, Christian},
+  journal={Biometrika},
+  pages={567--577},
+  year={1997},
+  publisher={JSTOR}
+}

--- a/src/Copulas.jl
+++ b/src/Copulas.jl
@@ -115,7 +115,10 @@ module Copulas
     include("Tail/MixedTail.jl")
     include("Tail/MOTail.jl")
     include("Tail/tEVTail.jl")
-
+    include("MiscellaneousCopulas/EmpiricalEVCopula.jl")
+    include("MiscellaneousCopulas/BernsteinCopula.jl")
+    include("MiscellaneousCopulas/BetaCopula.jl")
+    include("MiscellaneousCopulas/CheckerboardCopula.jl")
     # Archimax copulas (includes the BB4 and BB5 models)
     include("ArchimaxCopula.jl")
 
@@ -170,6 +173,12 @@ module Copulas
            WCopula,
            ArchimaxCopula,
            BB4Copula,
-           BB5Copula
+           BB5Copula,
+           EmpiricalEVCopula,
+           BernsteinCopula,
+           EmpiricalBernsteinCopula,
+           BetaCopula,
+           EmpiricalBetaCopula,
+           CheckerboardCopula
 
 end

--- a/src/MiscellaneousCopulas/BernsteinCopula.jl
+++ b/src/MiscellaneousCopulas/BernsteinCopula.jl
@@ -1,0 +1,235 @@
+"""
+    BernsteinCopula{d, C}
+
+Fields:
+- `base::C` - underlying copula
+- `m::NTuple{d,Int}` - polynomial degrees (smoothing parameters)
+
+Constructor
+
+    BernsteinCopula(C; m=10)
+    BernsteinCopula(data; m=10)
+    EmpiricalBernsteinCopula(data; m=10)
+
+The Bernstein copula in dimension ``d`` is defined as
+
+```math
+B_m(C)(u) = \\sum_{s_1=0}^{m_1} \\cdots \\sum_{s_d=0}^{m_d}C\\left(\\tfrac{s_1}{m_1}, \\ldots, \\tfrac{s_d}{m_d}\\right)\\prod_{j=1}^d \\binom{m_j}{s_j} u_j^{s_j}(1-u_j)^{m_j-s_j}.
+```
+
+It is a polynomial approximation of the base copula ``C`` using the multivariate Bernstein operator.
+
+Notes:
+
+- If ``C`` is an `EmpiricalCopula`, the constructor produces the *empirical Bernstein copula*, a smoothed version of the empirical copula.
+- Supports `cdf`, `logpdf` and random generation via mixtures of beta distributions.
+- The choice of `m` controls the smoothness of the approximation: larger `m` yields finer approximation but higher computational cost.
+
+References:
+* [sancetta2004bernstein](@cite) Sancetta, A., & Satchell, S. (2004). The Bernstein copula and its applications to modeling and approximations of multivariate distributions. Econometric Theory, 20(3), 535-562.
+* [segers2017empirical](@cite) Segers, J., Sibuya, M., & Tsukahara, H. (2017). The empirical beta copula. Journal of Multivariate Analysis, 155, 35-51.
+"""
+struct BernsteinCopula{d,C<:Copula} <: Copula{d}
+    base::C
+    m::NTuple{d,Int}
+end
+
+function BernsteinCopula(base::Copula; m::Union{Int,Tuple,Nothing}=10)
+    d = Copulas.length(base)
+
+    if m !== nothing
+        mtuple = (m isa Int) ? ntuple(_->m, d) : m
+        @assert length(mtuple) == d "The parameter m must have length $d"
+        if base isa EmpiricalCopula
+            n = size(base.u, 2)
+            for mj in mtuple
+                if n % mj != 0
+                    @warn "Sample size n=$n is not a multiple of m=$mj; partition may be unbalanced."
+                end
+            end
+        end
+        return BernsteinCopula{d,typeof(base)}(base, mtuple)
+    end
+
+    if base isa Copulas.EmpiricalCopula
+        n = size(base.u, 2)
+        m_est = max(2, floor(Int, n^(1/d)))
+        @info "Automatic choice: m=$m_est in each dimension (≈ n^(1/d))."
+        return BernsteinCopula{d,typeof(base)}(base, ntuple(_->m_est, d))
+    end
+
+    return BernsteinCopula{d,typeof(base)}(base, ntuple(_->10, d))
+end
+
+function BernsteinCopula(data::AbstractMatrix; m::Union{Int,Tuple,Nothing}=nothing)
+    EC = Copulas.EmpiricalCopula(data; pseudo_values=false)
+    return BernsteinCopula(EC; m=m)
+end
+
+EmpiricalBernsteinCopula(data::AbstractMatrix; m::Union{Int,Tuple,Nothing}=nothing) = BernsteinCopula(data; m=m)
+
+function delta_d(C::Copula, s::NTuple{d,Int}, m::NTuple{d,Int}) where {d}
+    total = zero(Float64)
+    @inbounds for ε in Iterators.product((0:1 for _ in 1:d)...)
+        u = [ (s[j] + ε[j]) / m[j] for j in 1:d ]
+        sign = (-1)^(d - sum(ε))
+        total += sign * Distributions.cdf(C, u)
+    end
+    return total
+end
+
+@inline function _bernvec_all(u::T, m::Int) where {T<:Real}
+    v = Vector{T}(undef, m+1)
+    if u == zero(T)
+        v[1] = one(T);  @inbounds for s in 2:m+1 v[s]=zero(T) end
+        return v
+    elseif u == one(T)
+        @inbounds for s in 1:m v[s]=zero(T) end; v[end]=one(T)
+        return v
+    end
+    one_minus_u = one(T) - u
+    p = one_minus_u^m
+    v[1] = p
+    @inbounds for s in 0:m-1
+        p *= ( (m - s) / (s + 1) ) * ( u / one_minus_u )
+        v[s+2] = p
+    end
+    return v
+end
+
+@inline function _betavec_pdf_all(u::T, m::Int) where {T<:Real}
+    v = Vector{T}(undef, m)
+    if u == zero(T)
+        v[1] = T(m); @inbounds for s in 2:m v[s]=zero(T) end
+        return v
+    elseif u == one(T)
+        @inbounds for s in 1:m-1 v[s]=zero(T) end; v[m]=T(m)
+        return v
+    end
+    one_minus_u = one(T) - u
+    q = one_minus_u^(m-1)
+    v[1] = T(m) * q
+    @inbounds for s in 0:m-2
+        q *= ( (m - 1 - s) / (s + 1) ) * ( u / one_minus_u )
+        v[s+2] = T(m) * q
+    end
+    return v
+end
+
+function Distributions.cdf(B::BernsteinCopula{d}, u::AbstractVector) where {d}
+    @assert length(u) == d
+    m = B.m
+
+    P = ntuple(j -> _bernvec_all(eltype(u)(u[j]), m[j]), d)
+    total = zero(eltype(first(P)))
+    @inbounds for s in Iterators.product((0:mi for mi in m)...)
+        coeff = Distributions.cdf(B.base, [s[j]/m[j] for j in 1:d])
+        basis = one(coeff)
+        @inbounds for j in 1:d
+            basis *= P[j][s[j]+1]
+        end
+        total += coeff * basis
+    end
+    return total
+end
+
+function Distributions.logpdf(B::BernsteinCopula{d}, u::AbstractVector) where {d}
+    @assert length(u) == d
+    m = B.m
+    BetaV = ntuple(j -> _betavec_pdf_all(eltype(u)(u[j]), m[j]), d)
+    dens = zero(eltype(first(BetaV)))
+    @inbounds for s in Iterators.product((0:(mi-1) for mi in m)...)
+        ΔC = delta_d(B.base, s, m)
+        if ΔC != 0.0
+            prodβ = one(ΔC)
+            @inbounds for j in 1:d
+                prodβ *= BetaV[j][s[j]+1]
+            end
+            dens += ΔC * prodβ
+        end
+    end
+    dens = max(dens, zero(dens))
+    return log(dens + eps(Float64))
+end
+
+function Distributions._rand!(rng::Distributions.AbstractRNG, B::BernsteinCopula{d}, u::AbstractVector{T}) where {d,T<:Real}
+    m = B.m
+    n = prod(mi for mi in m)
+
+    keys_ = Vector{NTuple{d,Int}}(undef, n)
+    vals_ = Vector{Float64}(undef, n)
+
+    k = 1
+    @inbounds for s in Iterators.product((0:(mi-1) for mi in m)...)
+        keys_[k] = s
+        vals_[k] = delta_d(B.base, s, m)
+        k += 1
+    end
+    @inbounds for i in eachindex(vals_)
+        if (vals_[i] < 0.0) && (vals_[i] > -sqrt(eps(Float64)))
+            vals_[i] = 0.0
+        end
+    end
+    S = sum(vals_)
+    S <= 0 && error("No positive mass in Δ; check base copula or m.")
+    vals_ ./= S
+
+    s = StatsBase.sample(rng, keys_, StatsBase.Weights(vals_))
+
+    @inbounds for j in 1:d
+        u[j] = Distributions.rand(rng, Distributions.Beta(s[j]+1, m[j]-s[j]))
+    end
+    return u
+end
+
+function _gridC_2d(base::Copula, m1::Int, m2::Int)
+    Tret = typeof(Distributions.cdf(base, [0.0, 0.0]))
+    M = Matrix{Tret}(undef, m1+1, m2+1)
+    @inbounds for s in 0:m1, t in 0:m2
+        M[s+1, t+1] = Distributions.cdf(base, [s/m1, t/m2])
+    end
+    return M
+end
+
+function _delta_2d(base::Copula, m1::Int, m2::Int)
+    Tret = typeof(Distributions.cdf(base, [0.0, 0.0]))
+    Δ = Matrix{Tret}(undef, m1, m2)
+    @inbounds for s in 0:m1-1, t in 0:m2-1
+        c11 = Distributions.cdf(base, [(s+1)/m1, (t+1)/m2])
+        c10 = Distributions.cdf(base, [(s+1)/m1, t/m2])
+        c01 = Distributions.cdf(base, [s/m1, (t+1)/m2])
+        c00 = Distributions.cdf(base, [s/m1, t/m2])
+        Δ[s+1, t+1] = c11 - c10 - c01 + c00
+    end
+    if Tret <: Real
+        w = vec(Δ)
+        @inbounds for k in eachindex(w)
+            if (w[k] < 0.0) && (w[k] > -sqrt(eps(Float64)))
+                w[k] = zero(Tret)
+            end
+        end
+    end
+    return Δ
+end
+
+function Distributions.cdf(B::BernsteinCopula{2}, u::AbstractVector)
+    @assert length(u) == 2
+    m1, m2 = B.m
+    bu = _bernvec_all(eltype(u)(u[1]), m1)
+    bv = _bernvec_all(eltype(u)(u[2]), m2)
+    M  = _gridC_2d(B.base, m1, m2)
+    t  = M * bv
+    return LinearAlgebra.dot(bu, t)
+end
+
+function Distributions.logpdf(B::BernsteinCopula{2}, u::AbstractVector)
+    @assert length(u) == 2
+    m1, m2 = B.m
+    βu = _betavec_pdf_all(eltype(u)(u[1]), m1)
+    βv = _betavec_pdf_all(eltype(u)(u[2]), m2)
+    Δ  = _delta_2d(B.base, m1, m2)
+    t  = Δ * βv
+    dens = LinearAlgebra.dot(βu, t)
+    dens = max(dens, zero(dens))
+    return log(dens + eps(Float64))
+end

--- a/src/MiscellaneousCopulas/BetaCopula.jl
+++ b/src/MiscellaneousCopulas/BetaCopula.jl
@@ -1,0 +1,183 @@
+"""
+    BetaCopula{d, MT}
+
+Fields:
+- `u::MT` - ranks-matrix (d × n)
+
+Constructor
+
+    BetaCopula(u)
+    EmpiricalBetaCopula(u)
+
+The empirical beta copula in dimension ``d`` is defined as
+
+```math
+C_n^{\\beta}(u) = \\frac{1}{n} \\sum_{i=1}^n \\prod_{j=1}^d F_{n,R_{ij}}(u_j),
+```
+
+where ``R_{ij}`` is the rank of observation ``i`` in margin ``j``, and ``U \\sim Beta(r, n+1-r)``.
+
+Notes:
+- This is always a valid copula for any finite sample size `n`.
+- Supports `cdf`, `logpdf` at observed points and random sampling.
+
+References:
+* [segers2017empirical](@cite) Segers, J., Sibuya, M., & Tsukahara, H. (2017). The empirical beta copula. Journal of Multivariate Analysis, 155, 35-51.
+"""
+############################
+#  Empirical Beta Copula   #
+############################
+############################
+#  Empirical Beta Copula   #
+############################
+
+struct BetaCopula{d,MT} <: Copula{d}
+    ranks::MT   # d×n (enteros 1..n en cada fila)
+    n::Int
+end
+
+# -- ranks por fila (variable) con ordinal ranks 1..n
+function _rowwise_ordinalranks(U::AbstractMatrix)
+    d, n = size(U)
+    R = Matrix{Int}(undef, d, n)
+    @inbounds for j in 1:d
+        R[j, :] = StatsBase.ordinalrank(@view U[j, :])
+    end
+    return R
+end
+
+function BetaCopula(data::AbstractMatrix)
+    U = _as_pxn(size(data,1), data)      # d×n
+    R = _rowwise_ordinalranks(U)         # d×n, enteros 1..n si no hay empates
+    # Comprobación rápida: cada fila debe ser una permutación de 1..n
+    @inbounds for j in 1:size(R,1)
+        if !all(sort(@view R[j,:]) .== 1:size(R,2))
+            @warn "Fila $j de ranks no es una permutación de 1..n; marginales pueden no ser uniformes."
+        end
+    end
+    return BetaCopula{size(U,1), typeof(R)}(R, size(U,2))
+end
+
+EmpiricalBetaCopula(data::AbstractMatrix) = BetaCopula(data)
+
+# =========================================
+#  Bases por recurrencia (AD y bordes safe)
+# =========================================
+# p_{n,k}(u) = C(n,k) u^k (1-u)^{n-k}, k=0..n
+# (Base de Bernstein grado n) — evita 0^0 y usa recurrencias estables.
+
+function _bernvec_n(u::T, n::Int) where {T<:Real}
+    v = Vector{T}(undef, n+1)
+    if u == zero(T)
+        v[1] = one(T); @inbounds for k in 2:n+1 v[k]=zero(T) end
+        return v
+    elseif u == one(T)
+        @inbounds for k in 1:n v[k]=zero(T) end; v[end]=one(T)
+        return v
+    end
+    one_minus_u = one(T) - u
+    p = one_minus_u^n
+    v[1] = p
+    @inbounds for k in 0:n-1
+        p *= ((n - k) / (k + 1)) * (u / one_minus_u)
+        v[k+2] = p
+    end
+    return v
+end
+
+# PDF Beta con parámetros enteros: f(u; r, n+1-r) = n * p_{n-1, r-1}(u)
+function _beta_pdf_basis(u::T, n::Int) where {T<:Real}
+    v = Vector{T}(undef, n)  # índices r=1..n
+    if u == zero(T)
+        v[1] = T(n); @inbounds for r in 2:n v[r]=zero(T) end
+        return v
+    elseif u == one(T)
+        @inbounds for r in 1:n-1 v[r]=zero(T) end; v[n]=T(n)
+        return v
+    end
+    p = _bernvec_n(u, n-1)               # k=0..n-1
+    @inbounds for r in 1:n
+        v[r] = T(n) * p[r]               # r ↔ k=r-1
+    end
+    return v
+end
+
+# CDF Beta con parámetros enteros: F_{n,r}(u) = ∑_{s=r}^{n} p_{n,s}(u)
+function _beta_cdf_basis(u::T, n::Int) where {T<:Real}
+    p = _bernvec_n(u, n)                 # p[k+1] ↔ p_{n,k}(u), k=0..n
+    tail = Vector{T}(undef, n+1)
+    acc = zero(T)
+    @inbounds for k in n:-1:0
+        acc += p[k+1]
+        tail[k+1] = acc                   # tail[k+1] = ∑_{s=k}^n p_{n,s}(u)
+    end
+    v = Vector{T}(undef, n)              # r = 1..n → tail[r+1] = ∑_{s=r}^n p_{n,s}(u)
+    @inbounds for r in 1:n
+        v[r] = tail[r+1]                 # <-- índice corregido
+    end
+    return v
+end
+
+# ========
+#   CDF
+# ========
+
+function Distributions.cdf(C::BetaCopula{d}, u::AbstractVector) where {d}
+    @assert length(u) == d
+    n = C.n
+    # tablas por dimensión en el punto u
+    CDFtab = ntuple(j -> _beta_cdf_basis(eltype(u)(u[j]), n), d)
+    total = zero(eltype(first(CDFtab)))
+    @inbounds for i in 1:n
+        prod_term = one(total)
+        @inbounds for j in 1:d
+            r = C.ranks[j,i]     # 1..n
+            prod_term *= CDFtab[j][r]
+            if prod_term == 0
+                break
+            end
+        end
+        total += prod_term
+    end
+    return total / n
+end
+
+# =========
+#  LOGPDF
+# =========
+
+function Distributions.logpdf(C::BetaCopula{d}, u::AbstractVector) where {d}
+    @assert length(u) == d
+    n = C.n
+    PDFtab = ntuple(j -> _beta_pdf_basis(eltype(u)(u[j]), n), d)
+    dens = zero(eltype(first(PDFtab)))
+    @inbounds for i in 1:n
+        prod_term = one(dens)
+        @inbounds for j in 1:d
+            r = C.ranks[j,i]
+            prod_term *= PDFtab[j][r]
+            if prod_term == 0
+                break
+            end
+        end
+        dens += prod_term
+    end
+    dens /= n
+    dens = max(dens, zero(dens))
+    return log(dens + eps(eltype(dens)))
+end
+
+# =========
+#  RAND!
+# =========
+
+function Distributions._rand!(rng::Distributions.AbstractRNG,
+                              C::BetaCopula{d},
+                              u::AbstractVector{T}) where {d,T<:Real}
+    i = Distributions.rand(rng, 1:C.n)  # elige componente de la mezcla
+    @inbounds for j in 1:d
+        r = C.ranks[j,i]
+        u[j] = Distributions.rand(rng, Distributions.Beta(r, C.n + 1 - r))
+    end
+    return u
+end

--- a/src/MiscellaneousCopulas/CheckerboardCopula.jl
+++ b/src/MiscellaneousCopulas/CheckerboardCopula.jl
@@ -1,0 +1,234 @@
+"""
+    CheckerboardCopula{d, MT}
+
+Fields:
+- `n::Int` — number of partitions per axis.
+- `h::MT`  — hypercubic array of cell masses (∑h = 1; each slice along an axis sums to 1/n).
+- `P::MT`  — inclusive prefix sums of `h` (for fast CDF evaluation).
+
+Constructor:
+
+    CheckerboardCopula(X; n=nothing, pseudo_values=true, smoothing=1e-16, maxiter=5000, atol=1e-12)
+
+The empirical checkerboard copula in dimension ``d`` is defined as the multilinear extension of the empirical copula:
+
+```math
+C_n^{\\mathrm{cb}}(u) = \\sum_{k} w_k(u) \\, C_n(v_k),
+```
+where ``v_k`` are the grid corners and ``w_k(u)`` the interpolation weights.
+
+Notes:
+
+- If `n` is `nothing`, is used `n = clamp(round(Int, m^(1/p)), 2, 256)`.
+- This is always a valid copula for any finite sample size `N`.
+- Supports `cdf`, `logpdf` at observed points and random sampling.
+
+References
+* Neslehova (2007). *On rank correlation measures for non-continuous random variables*.
+* Segers, Sibuya & Tsukahara (2017). *The empirical beta copula*. J. Multivariate Analysis, 155, 35-51.
+* Fredricks & Hofert (2025). *On the checkerboard copula and maximum entropy*.
+"""
+struct CheckerboardCopula{d,MT<:AbstractArray{<:Real,d}} <: Copula{d}
+    n::Int   # partitions by axis
+    h::MT    # masses per cell (∑h=1; each slice along an axis = 1/n)
+    P::MT    # inclusive prefixes of h (for fast CDF)
+end
+
+function CheckerboardCopula(X::AbstractMatrix{<:Real};
+                            n::Union{Int,Nothing}=nothing,
+                            pseudo_values::Bool=true,
+                            smoothing::Real=1e-16,
+                            maxiter::Int=5_000,
+                            atol::Real=1e-12)
+    U = _as_pxn(size(X,1), X)   # p×m
+    p, m = size(U)
+    n === nothing && (n = clamp(round(Int, m^(1/p)), 2, 256))
+
+    Uu = if pseudo_values
+        minU = minimum(U); maxU = maximum(U)
+        if !(minU ≥ -sqrt(eps(Float64)) && maxU ≤ 1 + sqrt(eps(Float64)))
+            throw(ArgumentError("Con pseudo_values=true, X debe estar ya en (0,1). Use pseudo_values=false o convierta con `pseudos(X)`."))
+        end
+        clamp.(Float64.(U), eps(Float64), 1 - eps(Float64))
+    else
+        pseudos(U)
+    end
+
+    H = zeros(Float64, ntuple(_->n, p))
+    @inbounds for t in 1:m
+        idx = ntuple(j -> _cell_and_tau(Uu[j, t], n)[1], p)  # 1..n por eje
+        H[CartesianIndex(idx)] += 1.0
+    end
+    H ./= m
+
+    _sinkhorn!(H; maxiter=maxiter, atol=atol, smoothing=smoothing)
+
+    P = _prefix_sum(H)
+
+    return CheckerboardCopula{p, typeof(H)}(n, H, P)
+end
+
+function Distributions.logpdf(C::CheckerboardCopula{d}, u::AbstractVector{<:Real}) where {d}
+    @assert length(u) == d
+    n = C.n
+    idx = ntuple(j -> begin
+        i, _ = _cell_and_tau(u[j], n)
+        i
+    end, d)
+    mass = @inbounds C.h[CartesianIndex(idx)]
+    dens = (mass <= 0) ? 0.0 : (mass * n^d)
+    return (dens > 0) ? log(dens) : -Inf
+end
+
+function Distributions.cdf(C::CheckerboardCopula{d}, u::AbstractVector{<:Real}) where {d}
+    @assert length(u) == d
+    n = C.n
+    idx = ntuple(j -> _cell_and_tau(u[j], n), d)  # (i_j, τ_j)
+    i   = ntuple(j -> idx[j][1], d)
+    τ   = ntuple(j -> idx[j][2], d)
+    k   = ntuple(j -> i[j]-1, d)
+
+    s0 = any(kj == 0 for kj in k) ? zero(eltype(C.h)) :
+         _sum_box(C.P, ntuple(_->1,d), k)
+
+    s = s0
+    for bt in _bit_tuples(Val(d))
+        # skip emptu
+        if all(b==0 for b in bt); continue; end
+        w = one(eltype(C.h))
+        @inbounds for j in 1:d
+            (bt[j]==1) && (w *= τ[j])
+        end
+        (w == 0) && continue
+        lows  = ntuple(j -> (bt[j]==1 ? k[j]+1 : 1), d)
+        highs = ntuple(j -> (bt[j]==1 ? k[j]+1 : k[j]), d)
+        s += w * _sum_box(C.P, lows, highs)
+    end
+    return float(s)
+end
+
+function Distributions._rand!(rng::Distributions.AbstractRNG, C::CheckerboardCopula{d}, u::AbstractVector{T}) where {d,T<:Real}
+    @assert length(u) == d
+    n = C.n
+    p = reshape(C.h, :)
+    cat = Distributions.Categorical(p ./ sum(p))
+    lin = rand(rng, cat)
+    I = CartesianIndices(size(C.h))[lin]
+    @inbounds for j in 1:d
+        a,b = _cell_bounds(I[j], n)
+        u[j] = a + rand(rng)*(b - a)
+    end
+    return u
+end
+
+
+# =========================
+#   Internal utils
+# =========================
+
+@inline function _cell_and_tau(u::Real, n::Int)
+    (u < 0 || u > 1) && throw(ArgumentError("u ∈ [0,1] requerido"))
+    if u == 1
+        return (n, 1.0)
+    else
+        t = n*u
+        k = Int(floor(t))  # 0..n-1
+        return (k+1, t - k)
+    end
+end
+
+@inline _cell_bounds(i::Int, n::Int) = ((i-1)/n, i/n)
+
+# inclusive prefix
+function _prefix_sum(h::AbstractArray{T,N}) where {T,N}
+    P = copy(h)
+    for ax in 1:N
+        P = cumsum(P; dims=ax)
+    end
+    return P
+end
+
+@generated function _bit_tuples(::Val{d}) where {d}
+    W = NTuple{d,Int}[]
+    for m in 0:(2^d-1)
+        push!(W, ntuple(j -> (m >> (j-1)) & 1, d))
+    end
+    return :(($(W...),))
+end
+
+@inline function _getP(P::AbstractArray{T,N}, idxs::NTuple{N,Int}) where {T,N}
+    @inbounds for j in 1:N
+        if idxs[j] == 0
+            return zero(T)
+        end
+    end
+    @inbounds return P[CartesianIndex(idxs)]
+end
+
+function _sum_box(P::AbstractArray{T,N}, l::NTuple{N,Int}, h::NTuple{N,Int}) where {T,N}
+    @inbounds for j in 1:N
+        if h[j] < l[j]; return zero(T); end
+    end
+    total = zero(T)
+    for bt in _bit_tuples(Val(N))
+        idxs = ntuple(j -> (bt[j] == 1 ? h[j] : l[j]-1), N)
+        sgn  = (-1)^(sum(bt[j]==0 for j in 1:N))
+        total += sgn * _getP(P, idxs)
+    end
+    total
+end
+
+@inline _sliceview(A, ax, t) = @view A[(ntuple(j -> (j==ax ? t : Colon()), ndims(A)))...]
+
+function _is_multistochastic(h::AbstractArray{T,d}; atol=1e-12) where {T,d}
+    n = size(h,1)
+    ndims(h) == d || throw(ArgumentError("ndims(h)=$(ndims(h)) ≠ d=$d"))
+    all(s -> s == n, size(h)) || throw(ArgumentError("h debe ser n×…×n"))
+
+    F = float(T); target = one(F)/n
+    @inbounds for x in h
+        (!isfinite(x) || x < -sqrt(eps(F))) && return false
+    end
+    @inbounds for ax in 1:d, t in 1:n
+        S = sum(_sliceview(h, ax, t))
+        if !isfinite(S) || abs(S - target) > atol
+            return false
+        end
+    end
+    S = sum(h)
+    isfinite(S) && abs(S - one(F)) ≤ atol
+end
+
+function _sinkhorn!(h::AbstractArray{T,d};
+                    maxiter::Int=5_000, atol::Real=1e-12, smoothing::Real=1e-16) where {T,d}
+    n = size(h,1)
+    ndims(h) == d || throw(ArgumentError("ndims(h)=$(ndims(h)) ≠ d=$d"))
+    all(s -> s == n, size(h)) || throw(ArgumentError("h debe ser n×…×n"))
+
+    F = float(T)
+    ε   = F(smoothing)
+    invN  = one(F)/n
+    invNd = one(F)/(n^d)
+
+    @. h = (one(F) - ε)*h + ε*invNd
+
+    for it in 1:maxiter
+        maxerr = zero(F)
+        @inbounds for ax in 1:d, t in 1:n
+            r = _sliceview(h, ax, t)
+            S = sum(r)
+            if S > 0
+                α = invN / S
+                @. r *= α
+                maxerr = max(maxerr, abs(S - invN))
+            else
+                fill!(r, invN/(n^(d-1)))
+                maxerr = max(maxerr, invN)
+            end
+        end
+        if maxerr ≤ atol
+            return h
+        end
+    end
+    h
+end

--- a/src/MiscellaneousCopulas/EmpiricalEVCopula.jl
+++ b/src/MiscellaneousCopulas/EmpiricalEVCopula.jl
@@ -1,0 +1,257 @@
+"""
+    EmpiricalEVTail
+
+Fields:
+  - `tgrid::Vector{Float64}` — evaluation grid in (0,1).
+  - `Ahat::Vector{Float64}`  — estimated Pickands function values on `tgrid`
+  - `slope::Vector{Float64}` — piecewise slopes used for linear interpolation
+
+Constructor
+
+  EmpiricalEVCopula(u; estimator=:ols, grid=401, eps=1e-3, pseudos=true)
+  ExtremeValueCopula(2, EmpiricalEVTail(u; ...))
+
+The empirical extreme-value copula (bivariate) is defined from pseudo-observations
+``u = (U_1, U_2)`` and a nonparametric estimator of the Pickands dependence function.
+Supported estimators are:
+
+* `:pickands` — classical Pickands estimator  
+* `:cfg`      — Capéraà-Fougères-Genest (CFG) estimator  
+* `:ols`      — OLS-intercept estimator  
+
+For stability, the estimated function is always **projected** onto the class of valid
+Pickands functions (convex, bounded between ``max(t,1-t)`` and 1, with endpoints fixed at 1).
+
+Its Pickands dependence function is given by
+
+```math
+\\hat A(t), \\quad t \\in (0,1),
+```
+
+evaluated by piecewise linear interpolation on the grid `tgrid`.
+
+Special cases:
+
+* If the data come from the independence copula, `\\hat A(t) \\approx 1`.
+* If the data come from an EV copula with true Pickands function ``A_{\\theta}(t)``, consistency ensures that `\\hat A(t) \\to A_{\\theta}(t)` as ``n \\to \\infty``.
+
+References:
+
+* [caperaa1997nonparametric](@cite) Capéraà, P., Fougères, A. L., & Genest, C. (1997). A nonparametric estimation procedure for bivariate extreme value copulas. Biometrika, 567-577.
+* [gudendorf2011nonparametric](@cite) Gudendorf, G., & Segers, J. (2011). Nonparametric estimation of an extreme-value copula in arbitrary dimensions. Journal of multivariate analysis, 102(1), 37-47.
+"""
+struct EmpiricalEVTail <: Tail2
+    tgrid::Vector{Float64}
+    Ahat::Vector{Float64}
+    slope::Vector{Float64}
+end
+_EULER_GAMMA = Base.MathConstants.eulergamma # maybe we defined constant???
+Base.eltype(::EmpiricalEVTail) = Float64
+Distributions.params(t::EmpiricalEVTail) = (tgrid = t.tgrid, Ahat = t.Ahat, slope = t.slope)
+function Base.summary(io::IO, t::EmpiricalEVTail)
+    print(io, "EmpiricalEVTail($(length(t.tgrid)) knots)")
+end
+@inline function _find_segment(tgrid::Vector{Float64}, t::Real)
+    # asume 0 < t < 1; fuera tratamos aparte
+    i = searchsortedlast(tgrid, t)
+    if i <= 0
+        return 0
+    elseif i >= length(tgrid)
+        return length(tgrid)    # marcador para el extremo derecho
+    else
+        return i
+    end
+end
+@inline _aslike(t, x::Real) = convert(typeof(t + t - t), x)
+# A(t)
+function A(tail::EmpiricalEVTail, t::Real)
+    tt = _safett(t)
+    tg, Ah = tail.tgrid, tail.Ahat
+
+    if tt <= 0.0 || tt >= 1.0
+        return _aslike(t, 1.0)  # A(0)=A(1)=1
+    end
+
+    i = _find_segment(tg, tt)
+    if i == 0
+        return _aslike(t, Ah[1])
+    elseif i >= length(tg)
+        return _aslike(t, Ah[end])
+    else
+        tL = tg[i]; tR = tg[i+1]
+        w  = (tt - tL) / (tR - tL)
+        return _aslike(t, (1 - w) * Ah[i] + w * Ah[i+1])
+    end
+end
+
+# dA(t)
+function dA(tail::EmpiricalEVTail, t::Real)
+    tt = _safett(t)
+    tg, sl = tail.tgrid, tail.slope
+    if tt <= 0.0 || tt >= 1.0
+        return _aslike(t, 0.0)
+    end
+    i = _find_segment(tg, tt)
+    if i <= 0 || i >= length(tg)
+        return _aslike(t, 0.0)
+    else
+        return _aslike(t, sl[i])
+    end
+end
+
+# A''(t) por tramos
+#d²A(::EmpiricalEVTail, ::Real) = 0.0
+#A(tail::EmpiricalEVTail, ω::NTuple{2,<:Real}) = A(tail, ω[1])
+
+# Estimador Pickands clasic
+function empirical_pickands(tgrid::AbstractVector, U::AbstractMatrix;
+                            pseudos_values::Bool=true, endpoint_correction::Bool=true)
+    Up = _as_pxn(2, U)
+    if pseudos_values
+        @assert all(0 .<= Up .<= 1)
+    else
+        Up = pseudos(Up)
+    end
+
+    lu = @views -log.(Up[1, :])
+    lv = @views -log.(Up[2, :])
+
+    Â = similar(tgrid, Float64)
+    @inbounds for (k, t) in pairs(tgrid)
+        tt = _safett(t)
+        ξ  = min.(lu ./ (1 - tt), lv ./ tt)
+        Â[k] = 1.0 / StatsBase.mean(ξ)
+    end
+    if endpoint_correction
+        Â[begin] = 1.0; Â[end] = 1.0
+    end
+    return Â
+end
+
+
+# Estimator CFG
+function empirical_pickands_cfg(tgrid::AbstractVector, U::AbstractMatrix;
+                                pseudos_values::Bool=true, endpoint_correction::Bool=true)
+    Up = _as_pxn(2, U)
+    if pseudos_values
+        @assert all(0 .<= Up .<= 1)
+    else
+        Up = pseudos(Up)
+    end
+    lu = @views -log.(Up[1, :])
+    lv = @views -log.(Up[2, :])
+    Â = similar(tgrid, Float64)
+    @inbounds for (k, t) in pairs(tgrid)
+        tt = _safett(t)
+        ξ  = min.(lu ./ (1 - tt), lv ./ tt)
+        Â[k] = exp(-_EULER_GAMMA - StatsBase.mean(log.(ξ)))
+    end
+    if endpoint_correction
+        Â[begin] = 1.0; Â[end] = 1.0
+    end
+    return Â
+end
+
+# Estimator OLS (intercept)
+function empirical_pickands_ols(tgrid::AbstractVector, U::AbstractMatrix;
+                                pseudos_values::Bool=true, endpoint_correction::Bool=true)
+    Up = _as_pxn(2, U)
+    if pseudos_values
+        @assert all(0 .<= Up .<= 1)
+    else
+        Up = pseudos(Up)
+    end
+    n  = size(Up, 2)
+    lu = @views -log.(Up[1, :])                # -log U_i
+    lv = @views -log.(Up[2, :])                # -log V_i
+    x1 = @views -log.(lu) .- _EULER_GAMMA
+    x2 = @views -log.(lv) .- _EULER_GAMMA
+
+    Z = Matrix{Float64}(undef, n, 3)
+    @inbounds Z[:,1] .= 1.0; Z[:,2] .= x1; Z[:,3] .= x2
+    ZtZ = LinearAlgebra.Symmetric(Z'Z)
+    F   = LinearAlgebra.cholesky(ZtZ)         # Pracitcal possitive def
+    P   = F \ (Z')              # (Z'Z)^(-1) Z'
+
+    Â = similar(tgrid, Float64)
+    y  = similar(lu)
+    @inbounds for (k, t) in pairs(tgrid)
+        tt = _safett(t)
+        ξt = min.(lu ./ (1 - tt), lv ./ tt)
+        @. y = -log(ξt) - _EULER_GAMMA
+        β  = P * y
+        Â[k] = exp(β[1])       # intercepto
+    end
+    if endpoint_correction
+        Â[begin] = 1.0; Â[end] = 1.0
+    end
+    return Â
+end
+
+function _convexify_pickands!(Â::Vector{Float64}, t::Vector{Float64})
+    n = length(Â); @assert n == length(t) && n ≥ 2
+    @inbounds for i in 1:n
+        Â[i] = clamp(Â[i], max(t[i], 1 - t[i]), 1.0)
+    end
+
+    Δt = diff(t)
+    s  = [(Â[i+1]-Â[i])/Δt[i] for i=1:n-1]
+    W  = copy(Δt)                             
+    C  = ones(Int, n-1)
+
+    i = 1
+    while i < length(s)
+        if s[i] <= s[i+1] + 1e-14
+            i += 1
+        else
+            newW = W[i] + W[i+1]
+            newS = (s[i]*W[i] + s[i+1]*W[i+1]) / newW
+            s[i] = newS; W[i] = newW; C[i] += C[i+1]
+            deleteat!(s, i+1); deleteat!(W, i+1); deleteat!(C, i+1)
+            if i > 1; i -= 1; end
+        end
+    end
+
+    s_exp = similar(Δt)
+    pos = 1
+    @inbounds for j in 1:length(s)
+        cnt = C[j]
+        for _ in 1:cnt
+            s_exp[pos] = s[j]
+            pos += 1
+        end
+    end
+    @assert pos-1 == length(Δt)
+
+    Â[2:end] = Â[1] .+ cumsum(s_exp .* Δt)
+    @inbounds for i in 1:n
+        Â[i] = clamp(Â[i], max(t[i], 1 - t[i]), 1.0)
+    end
+    return Â, s_exp
+end
+
+"""
+    EmpiricalEVTail(u; kwargs...)
+
+Construct the empirical tail (Pickands) from data (2×N or N×2).
+"""
+function EmpiricalEVTail(u::AbstractMatrix; estimator::Symbol=:ols, grid::Int=401, eps::Real=1e-3, pseudos_values::Bool=true)
+    # Orientación 2×n con tu helper
+    Up = _as_pxn(2, u)
+    if pseudos_values
+        @assert all(0 .<= Up .<= 1)
+    else
+        Up = pseudos(Up)
+    end
+
+    tgrid = collect(range(eps, 1 - eps; length=grid))
+
+    Â = estimator === :ols      ? empirical_pickands_ols(tgrid, Up; pseudos_values=true) :
+         estimator === :cfg      ? empirical_pickands_cfg(tgrid, Up; pseudos_values=true) :
+         estimator === :pickands ? empirical_pickands(tgrid, Up; pseudos_values=true) :
+         throw(ArgumentError("estimator ∈ {:ols,:cfg,:pickands}"))
+    Â, slope = _convexify_pickands!(Â, tgrid)
+    return EmpiricalEVTail(tgrid, Â, slope)
+end
+
+EmpiricalEVCopula(u; kwargs...) = ExtremeValueCopula(2, EmpiricalEVTail(u; kwargs...))

--- a/src/Tail/AsymGalambosTail.jl
+++ b/src/Tail/AsymGalambosTail.jl
@@ -3,16 +3,16 @@
 
 Fields:
   - α::Real          — dependence parameter
-    - θ₁::Real — asymmetry weight in [0,1]
-    - θ₂::Real — asymmetry weight in [0,1]
+  - θ₁::Real — asymmetry weight in [0,1]
+  - θ₂::Real — asymmetry weight in [0,1]
 
 Constructor
 
     AsymGalambosCopula(α, θ)         # θ as a 2-vector/tuple
     ExtremeValueCopula(2, AsymGalambosTail(α, θ))
 
-The (bivariate) asymmetric Galambos extreme–value copula is parameterized by
-``\\alpha \\in [0, \\infty) and ``\\theta_1, \\theta_2 \\in [0,1]``. It is an EV copula with Pickands function
+The (bivariate) asymmetric Galambos extreme-value copula is parameterized by
+``\\alpha \\in [0, \\infty)`` and ``\\theta_1, \\theta_2 \\in [0,1]``. It is an EV copula with Pickands function
 
 ```math
 A(t) = 1 - \\Big((\\theta_1 t)^{-\\alpha} + (\\theta_2(1-t))^{-\\alpha}\\Big)^{-1/\\alpha},\\quad t\\in[0,1].

--- a/src/Tail/AsymLogTail.jl
+++ b/src/Tail/AsymLogTail.jl
@@ -2,9 +2,9 @@
     AsymLogTail{T}
 
 Fields:
-    - α::Real  — dependence parameter (α ≥ 1)
-    - θ₁::Real — asymmetry weight in [0,1]
-    - θ₂::Real — asymmetry weight in [0,1]
+  - α::Real  — dependence parameter (α ≥ 1)
+  - θ₁::Real — asymmetry weight in [0,1]
+  - θ₂::Real — asymmetry weight in [0,1]
 
 Constructor
 

--- a/src/Tail/tEVTail.jl
+++ b/src/Tail/tEVTail.jl
@@ -19,7 +19,7 @@ A(x) = xt_{\\nu+1}(Z_x) +(1-x)t_{\\nu+1}(Z_{1-x})
 Where ``t_{\\nu + 1}`` is the cumulative distribution function (CDF) of the standard t distribution with ``\\nu + 1`` degrees of freedom and
 
 ```math
-Z_x = \\frac{(1+\\nu)^{1/2}{\\sqrt{1-\\theta^2}}\\left [ \\left (\\frac{x}{1-x} \\right )^{1/\\nu} - \\theta \\right ]
+Z_x = \\frac{(1+\\nu)^{1/2}{\\sqrt{1-\\theta^2}}\\left[ \\left(\\frac{x}{1-x} \\right)^{1/\\nu} - \\theta \\right]
 ```
 
 Special cases:

--- a/src/show.jl
+++ b/src/show.jl
@@ -28,3 +28,27 @@ end
 function Base.show(io::IO, C::SubsetCopula)
     print(io, "SubsetCopula($(C.C), $(C.dims))")
 end
+
+function Base.show(io::IO, tail::EmpiricalEVTail)
+    print(io, "EmpiricalEVTail(", length(tail.tgrid), " knots)")
+end
+
+function Base.show(io::IO, C::ExtremeValueCopula{2, EmpiricalEVTail})
+    print(io, "ExtremeValueCopula{2} ⟨", C.tail, "⟩")
+end
+
+function Base.show(io::IO, B::BernsteinCopula{d,C}) where {d,C<:Copulas.Copula}
+    if B.base isa Copulas.EmpiricalCopula
+        print(io, "EmpiricalBernsteinCopula{", d, "} ⟨n=", size(B.base.u,2), ", m=", B.m, "⟩")
+    else
+        print(io, "BernsteinCopula{", d, "} ⟨base=", nameof(C), ", m=", B.m, "⟩")
+    end
+end
+
+function Base.show(io::IO, C::BetaCopula)
+    print(io, "EmpiricalBetaCopula{d}$(size(C.ranks))")
+end
+
+function Base.show(io::IO, C::CheckerboardCopula{d}) where {d}
+    print(io, "CheckerboardCopula{", d, "} ⟨n=", C.n, "⟩")
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -12,3 +12,4 @@ pseudos(sample) = transpose(hcat([StatsBase.ordinalrank(sample[i,:])./(size(samp
 @inline _δ(t) = oftype(t, 1e-12)
 @inline _safett(t) = clamp(t, _δ(t), one(t) - _δ(t))
 @inline _as_tuple(x) = x isa Tuple ? x : (x,)
+@inline _as_pxn(p::Integer, U::AbstractMatrix) = (size(U,1) == p) ? U : permutedims(U)

--- a/test/ExtremeValueCopulas.jl
+++ b/test/ExtremeValueCopulas.jl
@@ -80,6 +80,13 @@
 @testitem "Generic" tags=[:Generic, :ExtremeValueCopula, :LogCopula] setup=[M] begin M.check(LogCopula(1.5)) end
 @testitem "Generic" tags=[:Generic, :ExtremeValueCopula, :LogCopula] setup=[M] begin M.check(LogCopula(5.5)) end
 
+@testitem "Generic" tags=[:Generic, :ExtremeValueCopula, :EmpiricalEVCopula] setup=[M] begin M.check(EmpiricalEVCopula(randn(2,10); estimator=:ols, pseudos_values=false)) end
+@testitem "Generic" tags=[:Generic, :ExtremeValueCopula, :EmpiricalEVCopula] setup=[M] begin M.check(EmpiricalEVCopula(randn(2,20); estimator=:ols, pseudos_values=false)) end
+@testitem "Generic" tags=[:Generic, :ExtremeValueCopula, :EmpiricalEVCopula] setup=[M] begin M.check(EmpiricalEVCopula(randn(2,10); estimator=:pickands, pseudos_values=false)) end
+@testitem "Generic" tags=[:Generic, :ExtremeValueCopula, :EmpiricalEVCopula] setup=[M] begin M.check(EmpiricalEVCopula(randn(2,20); estimator=:pickands, pseudos_values=false)) end
+@testitem "Generic" tags=[:Generic, :ExtremeValueCopula, :EmpiricalEVCopula] setup=[M] begin M.check(EmpiricalEVCopula(randn(2,10); estimator=:cfg, pseudos_values=false)) end
+@testitem "Generic" tags=[:Generic, :ExtremeValueCopula, :EmpiricalEVCopula] setup=[M] begin M.check(EmpiricalEVCopula(randn(2,20); estimator=:cfg, pseudos_values=false)) end
+
 @testitem "Checking LogCopula == GumbelCopula" tags=[:ExtremeValueCopula, :LogCopula, :ArchimedeanCopula, :GumbelCopula] begin
     # [GenericTests integration]: Probably too specific (equivalence between two constructors/types). Could be a targeted identity test, keep here.
     using InteractiveUtils

--- a/test/MiscelaneousCopulas.jl
+++ b/test/MiscelaneousCopulas.jl
@@ -26,6 +26,24 @@
 @testitem "Generic" tags=[:Generic, :SurvivalCopula] setup=[M] begin M.check(SurvivalCopula(ClaytonCopula(2,-0.7),(1,2))) end
 @testitem "Generic" tags=[:Generic, :SurvivalCopula] setup=[M] begin M.check(SurvivalCopula(RafteryCopula(2, 0.2), (2,1))) end
 
+@testitem "Generic" tags=[:Generic, :BernsteinCopula] setup=[M] begin M.check(BernsteinCopula(GaussianCopula([1.0 0.3; 0.3 1.0]); m=5)) end
+@testitem "Generic" tags=[:Generic, :BernsteinCopula] setup=[M] begin M.check(BernsteinCopula(IndependentCopula(4);m=5)) end
+@testitem "Generic" tags=[:Generic, :BernsteinCopula] setup=[M] begin M.check(BernsteinCopula(GalambosCopula(2.5);m=5)) end
+@testitem "Generic" tags=[:Generic, :BernsteinCopula] setup=[M] begin M.check(BernsteinCopula(ArchimaxCopula(2, Copulas.FrankGenerator(0.8), Copulas.HuslerReissTail(0.6)); m=5)) end
+@testitem "Generic" tags=[:Generic, :BernsteinCopula] setup=[M] begin M.check(BernsteinCopula(ClaytonCopula(3, 3.3);m=5)) end
+@testitem "Generic" tags=[:Generic, :BernsteinCopula] setup=[M] begin M.check(BernsteinCopula(IndependentCopula(4);m=5)) end
+@testitem "Generic" tags=[:Generic, :BernsteinCopula] setup=[M] begin M.check(BernsteinCopula(randn(2,100))) end
+@testitem "Generic" tags=[:Generic, :BernsteinCopula] setup=[M] begin M.check(EmpiricalBernsteinCopula(randn(2,100))) end
+
+@testitem "Generic" tags=[:Generic, :BetaCopula] setup=[M] begin M.check(BetaCopula(randn(2,100))) end
+@testitem "Generic" tags=[:Generic, :BetaCopula] setup=[M] begin M.check(BetaCopula(randn(3,100))) end
+@testitem "Generic" tags=[:Generic, :BetaCopula] setup=[M] begin M.check(EmpiricalBetaCopula(randn(2,100))) end
+@testitem "Generic" tags=[:Generic, :BetaCopula] setup=[M] begin M.check(EmpiricalBetaCopula(randn(3,100))) end
+
+@testitem "Generic" tags=[:Generic, :CheckerboardCopula] setup=[M] begin M.check(CheckerboardCopula(randn(2,100); pseudo_values=false)) end
+@testitem "Generic" tags=[:Generic, :CheckerboardCopula] setup=[M] begin M.check(CheckerboardCopula(randn(3,100); pseudo_values=false)) end
+@testitem "Generic" tags=[:Generic, :CheckerboardCopula] setup=[M] begin M.check(CheckerboardCopula(randn(4,100); pseudo_values=false)) end
+
 @testitem "Testing survival stuff" tags=[:SurvivalCopula] begin
     # [GenericTests integration]: Yes. Symmetry of survival transformations on pdf/cdf is generic; we can add survival invariance checks.
     using Distributions

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,4 +4,5 @@ using TestItemRunner
 # @run_package_tests filter=ti->(:GumbelBarnettCopula in ti.tags || :ArchimedeanCopula in ti.tags || :FrankCopula in ti.tags)
 # you can add verbose=true here 
 
-@run_package_tests
+@run_package_tests filter=ti->(:BernsteinCopula in ti.tags || :BetaCopulaCopula in ti.tags ||:CheckerboardCopula in ti.tags
+|| :EmpiricalEVCopula in ti.tags)


### PR DESCRIPTION
Hi Oskar, in the spirit of moving forward with the fit API, I decided to include these important empirical copulas known in the literature... I believe they're also in the Roadmap. However, I'm having some issues with the tests.

1. In `BernsteinCopula` and `BetaCopula`, I don't know which tests are broken.
2. In `EmpiricalEVCopula`, anything that implements the second derivative of A will fail, such as pdf and the Rosenblat functions. This is because it's a discrete function, and the second derivative will return zero.
3. In `CheckerboardCopula`, I noticed that some tests don't pass; however, I think it's a numerical problem. It should be 1, but we get `0.999999999`. In this case I tried to implement it following this representation https://www.degruyterbrill.com/document/doi/10.1515/demo-2020-0004/html

Do you think you could take a look?