### PR TITLE
Update Aqua.jl test structure and clarify persistent task handling

### DIFF
--- a/test/Aqua.jl
+++ b/test/Aqua.jl
@@ -1,7 +1,8 @@
 @testitem "Aqua.jl" begin
-    using Aqua
-    Aqua.test_all(
-      Copulas;
-      ambiguities=false,
-    )
+  using Aqua
+  Aqua.test_all(
+    Copulas;
+    persistent_tasks = VERSION != v"1.10.10", # Disable persistent tasks only on Julia 1.10.10 (workaround for that release)
+    ambiguities = false,
+  )
 end


### PR DESCRIPTION
Revise the test structure in Aqua.jl to improve clarity and address persistent task handling, specifically disabling it for Julia version 1.10.10 as a workaround.