### PR TITLE
[Internals] Back to TaylorSeries.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -24,7 +24,7 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 StatsFuns = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
-WilliamsonTransforms = "48feb556-9bdd-43a2-8e10-96100ec25e22"
+TaylorSeries = "6aa5eb33-94cf-58f4-a9d0-e4b2c4fc25ea"
 
 [weakdeps]
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
@@ -59,9 +59,9 @@ StableRNGs = "1"
 Statistics = "1"
 StatsBase = "0.33, 0.34"
 StatsFuns = "0.9, 1.3"
+TaylorSeries = "0.18.5"
 Test = "1"
 TestItemRunner = "1"
-WilliamsonTransforms = "0.2"
 julia = "1"
 
 [extras]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@
      <a href="https://github.com/lrnv/Copulas.jl/actions/workflows/CI.yml?query=branch%3Amain"><img src="https://github.com/lrnv/Copulas.jl/actions/workflows/CI.yml/badge.svg?branch=main" alt="Build Status" /></a>
      <a href="https://codecov.io/gh/lrnv/Copulas.jl"><img src="https://codecov.io/gh/lrnv/Copulas.jl/branch/main/graph/badge.svg"/></a>
      <a href="https://github.com/JuliaTesting/Aqua.jl"><img src="https://raw.githubusercontent.com/JuliaTesting/Aqua.jl/master/badge.svg" alt="Aqua QA" /></a>
-    <!-- <a href="https://benchmark.tansongchen.com/TaylorDiff.jl"><img src="https://img.shields.io/buildkite/2c801728055463e7c8baeeb3cc187b964587235a49b3ed39ab/main.svg?label=benchmark" alt="Benchmark Status" /></a> -->
 <br />
     <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT" /></a>
     <a href="https://github.com/SciML/ColPrac"><img src="https://img.shields.io/badge/contributor's%20guide-ColPrac-blueviolet" alt="ColPrac: Contributor's Guide on Collaborative Practices for Community Packages" /></a>

--- a/docs/src/bestiary/archimedean.md
+++ b/docs/src/bestiary/archimedean.md
@@ -96,7 +96,7 @@ In this package, we implemented it through the [`WilliamsonGenerator`](@ref) cla
 
 `WilliamsonGenerator(X::UnivariateRandomVariable, d)`.
 
-This function computes the Williamson d-transform of the provided random variable $X$ using the [`WilliamsonTransforms.jl`](https://github.com/lrnv/WilliamsonTransforms.jl) package. See [williamson1955multiply, mcneil2009](@cite) for the literature. 
+This function computes the Williamson d-transform of the provided random variable $X$. See [williamson1955multiply, mcneil2009](@cite) for the literature. 
 
 !!! info "`max_monotony` of Williamson generators"
     The $d$-transform of a positive random variable is $d$-monotone but not $k$-monotone for any $k > d$. Its max monotony is therefore $d$. This has a few implications, one of the biggest is that the $d$-variate Archimedean copula that corresponds has no density.
@@ -115,7 +115,7 @@ The Williamson d-transform is a bijective transformation[^1] from the set of pos
 
     This bijection is to be taken carefuly: the bijection is between random variables *with unit scales* and generators *with common value at 1*, sicne on both rescaling does not change the underlying copula. 
 
-This transformation is implemented through one method in the Generator interface that is worth talking a bit about : `williamson_dist(G::Generator, d)`. This function computes the inverse Williamson d-transform of the d-monotone archimedean generator ϕ, still using the [`WilliamsonTransforms.jl`](https://github.com/lrnv/WilliamsonTransforms.jl) package. See [williamson1955multiply, mcneil2009](@cite).
+This transformation is implemented through one method in the Generator interface that is worth talking a bit about : `williamson_dist(G::Generator, d)`. This function computes the inverse Williamson d-transform of the d-monotone archimedean generator ϕ. See [williamson1955multiply, mcneil2009](@cite).
 
 To put it in a nutshell, for ``\phi`` a ``d``-monotone archimedean generator, the inverse Williamson-d-transform of ``\\phi`` is the cumulative distribution function ``F`` of a non-negative random variable ``R``, defined by : 
 
@@ -123,7 +123,7 @@ To put it in a nutshell, for ``\phi`` a ``d``-monotone archimedean generator, th
 F(x) = 𝒲_{d}^{-1}(\phi)(x) = 1 - \frac{(-x)^{d-1} \phi_+^{(d-1)}(x)}{k!} - \sum_{k=0}^{d-2} \frac{(-x)^k \phi^{(k)}(x)}{k!}
 ```
 
-The [`WilliamsonTransforms.jl`](https://github.com/lrnv/WilliamsonTransforms.jl) package implements this transformation (and its inverse, the Williamson d-transfrom) in all generality. It returns this cumulative distribution function in the form of the corresponding random variable `<:Distributions.ContinuousUnivariateDistribution` from `Distributions.jl`. You may then compute : 
+It returns this cumulative distribution function in the form of the corresponding random variable `<:Distributions.ContinuousUnivariateDistribution` from `Distributions.jl`. You may then compute : 
 * The cdf via `Distributions.cdf`
 * The pdf via `Distributions.pdf` and the logpdf via `Distributions.logpdf`
 * Samples from the distribution via `rand(X,n)`.

--- a/src/Copulas.jl
+++ b/src/Copulas.jl
@@ -12,7 +12,6 @@ module Copulas
     import ForwardDiff
     import HCubature
     import MvNormalCDF
-    import WilliamsonTransforms
     import Combinatorics
     import LogExpFunctions
     import QuadGK
@@ -22,6 +21,7 @@ module Copulas
     import LambertW
     import Optim
     import Printf
+    import TaylorSeries
 
     # Main code
     include("utils.jl")
@@ -82,6 +82,7 @@ module Copulas
     include("EllipticalCopulas/TCopula.jl")
 
     # Archimedean copulas
+    include("WilliamsonTransforms.jl")
     include("Generator.jl")
     include("ArchimedeanCopula.jl")
 

--- a/src/Generator.jl
+++ b/src/Generator.jl
@@ -26,7 +26,7 @@ More methods can be implemented for performance, althouhg there are implement de
 * `ϕ⁽¹⁾(G::Generator, t)` gives the first derivative of the generator
 * `ϕ⁽ᵏ⁾(G::Generator, ::Val{k}, t) where k` gives the kth derivative of the generator
 * `ϕ⁻¹⁽¹⁾(G::Generator, t)` gives the first derivative of the inverse generator.
-* `williamson_dist(G::Generator, ::Val{d}) where d` gives the Wiliamson d-transform of the generator, see [WilliamsonTransforms.jl](https://github.com/lrnv/WilliamsonTransforms.jl).
+* `williamson_dist(G::Generator, ::Val{d}) where d` gives the Wiliamson d-transform of the generator.
 
 References:
 * [mcneil2009](@cite) McNeil, A. J., & Nešlehová, J. (2009). Multivariate Archimedean copulas, d-monotone functions and ℓ 1-norm symmetric distributions.
@@ -44,9 +44,9 @@ max_monotony(G::Generator) = throw("This generator does not have a defined max m
 ϕ⁻¹( G::Generator, x) = Roots.find_zero(t -> ϕ(G,t) - x, (0.0, Inf))
 ϕ⁽¹⁾(G::Generator, t) = ForwardDiff.derivative(x -> ϕ(G,x), t)
 ϕ⁻¹⁽¹⁾(G::Generator, t) = ForwardDiff.derivative(x -> ϕ⁻¹(G, x), t)
-ϕ⁽ᵏ⁾(G::Generator, ::Val{k}, t) where k = WilliamsonTransforms.taylor(ϕ(G), t, Val{k}())[end] * factorial(k)
+ϕ⁽ᵏ⁾(G::Generator, ::Val{k}, t) where k = taylor(ϕ(G), t, Val{k}())[end] * factorial(k)
 ϕ⁽ᵏ⁾⁻¹(G::Generator, ::Val{k}, t; start_at=t) where {k} = Roots.find_zero(x -> ϕ⁽ᵏ⁾(G, Val{k}(), x) - t, start_at)
-williamson_dist(G::Generator, ::Val{d}) where d = WilliamsonTransforms.𝒲₋₁(ϕ(G), Val{d}())
+williamson_dist(G::Generator, ::Val{d}) where d = 𝒲₋₁(ϕ(G), Val{d}())
 
 
 # TODO: Move the \phi^(1) to defer to \phi^(k=1), and implement \phi(k=1) in generators instead of \phi^(1)
@@ -138,7 +138,7 @@ Constructor
     WilliamsonGenerator(atoms::AbstractVector, weights::AbstractVector, d)
     i𝒲(atoms::AbstractVector, weights::AbstractVector, d)
 
-The `WilliamsonGenerator` (alias `i𝒲`) allows to construct a d-monotonous archimedean generator from a positive random variable `X::Distributions.UnivariateDistribution`. The transformation, which is called the inverse Williamson transformation, is implemented in [WilliamsonTransforms.jl](https://www.github.com/lrnv/WilliamsonTransforms.jl). 
+The `WilliamsonGenerator` (alias `i𝒲`) allows to construct a d-monotonous archimedean generator from a positive random variable `X::Distributions.UnivariateDistribution`. The transformation, which is called the inverse Williamson transformation, is implemented fully generically in the package. 
 
 For a univariate non-negative random variable ``X``, with cumulative distribution function ``F`` and an integer ``d\\ge 2``, the Williamson-d-transform of ``X`` is the real function supported on ``[0,\\infty[`` given by:
 
@@ -165,8 +165,7 @@ Special case (finite-support discrete X)
 
 - If `X isa Distributions.DiscreteUnivariateDistribution` and `support(X)` is finite, or if you pass directly atoms and weights to the constructor, the produced generator is piecewise-polynomial `ϕ(t) = ∑_j w_j · (1 − t/r_j)_+^(d−1)` matching the Williamson transform of a discrete radial law. It has specialized methods. 
 - For infinite-support discrete distributions or when the support is not accessible as a finite
-    iterable, the standard `WilliamsonGenerator` is constructed and will defer to
-    `WilliamsonTransforms.jl`.
+    iterable, the standard `WilliamsonGenerator` is constructed.
 
 References: 
 * [williamson1955multiply](@cite) Williamson, R. E. (1956). Multiply monotone functions and their Laplace transforms. Duke Math. J. 23 189–207. MR0077581
@@ -206,7 +205,7 @@ WilliamsonGenerator(r, w, d::Int) = WilliamsonGenerator(r, w, Val(d))
 Distributions.params(G::WilliamsonGenerator) = (G.X,)
 max_monotony(::WilliamsonGenerator{d, TX}) where {d, TX} = d
 williamson_dist(G::WilliamsonGenerator{d, TX}, ::Val{d}) where {d, TX} = G.X # if its the right dim. 
-ϕ(G::WilliamsonGenerator{d, TX}, t) where {d, TX} = WilliamsonTransforms.𝒲(G.X, Val{d}())(t)
+ϕ(G::WilliamsonGenerator{d, TX}, t) where {d, TX} = 𝒲(G.X, Val{d}())(t)
 
 # TODO: The following method for Kendall's tau is currently faulty and produces incorrect results.
 # τ(G::WilliamsonGenerator) = 4*Distributions.expectation(Base.Fix1(ϕ, G), Copulas.williamson_dist(G, Val(2)))-1 # McNeil & Neshelova 2009

--- a/src/Generator/AMHGenerator.jl
+++ b/src/Generator/AMHGenerator.jl
@@ -95,7 +95,7 @@ end
 ϕ⁽¹⁾(G::AMHGenerator, t) = -((1-G.θ) * exp(t)) / (exp(t) - G.θ)^2
 ϕ⁽ᵏ⁾(G::AMHGenerator, ::Val{k}, t) where k = (-1)^k * (1 - G.θ) / G.θ * PolyLog.reli(-k, G.θ * exp(-t))
 ϕ⁻¹⁽¹⁾(G::AMHGenerator, t) = (G.θ - 1) / (G.θ * (t - 1) * t + t)
-williamson_dist(G::AMHGenerator, ::Val{d}) where d = G.θ >= 0 ? WilliamsonFromFrailty(1 + Distributions.Geometric(1-G.θ),Val{d}()) : WilliamsonTransforms.𝒲₋₁(t -> ϕ(G,t),Val{d}())
+williamson_dist(G::AMHGenerator, ::Val{d}) where d = G.θ >= 0 ? WilliamsonFromFrailty(1 + Distributions.Geometric(1-G.θ),Val{d}()) : 𝒲₋₁(t -> ϕ(G,t),Val{d}())
 frailty(G::AMHGenerator) = G.θ >= 0 ? Distributions.Geometric(1-G.θ) : throw("No frailty exists for AMH when θ < 0")
 function _amh_tau(θ)
     if abs(θ) < 0.01

--- a/src/Generator/FrankGenerator.jl
+++ b/src/Generator/FrankGenerator.jl
@@ -53,7 +53,7 @@ function ϕ⁽ᵏ⁾(G::FrankGenerator, ::Val{k}, t) where k
     return (-1)^k * (1 / G.θ) * PolyLog.reli(-(k - 1), -expm1(-G.θ) * exp(-t))
 end
 ϕ⁻¹(G::FrankGenerator, t) = G.θ > 0 ? LogExpFunctions.log1mexp(-G.θ) - LogExpFunctions.log1mexp(-t*G.θ) : -log(expm1(-t*G.θ)/expm1(-G.θ))
-williamson_dist(G::FrankGenerator, ::Val{d}) where d = G.θ > 0 ? WilliamsonFromFrailty(Logarithmic(-G.θ), Val{d}()) : WilliamsonTransforms.𝒲₋₁(t -> ϕ(G,t),Val{d}())
+williamson_dist(G::FrankGenerator, ::Val{d}) where d = G.θ > 0 ? WilliamsonFromFrailty(Logarithmic(-G.θ), Val{d}()) : 𝒲₋₁(t -> ϕ(G,t),Val{d}())
 frailty(G::FrankGenerator) = G.θ > 0 ? Logarithmic(-G.θ) : throw("The frank copula has no frailty when θ < 0")
 
 Debye(x, k::Int=1) = k / x^k * QuadGK.quadgk(t -> t^k/expm1(t), 0, x)[1]

--- a/src/WilliamsonTransforms.jl
+++ b/src/WilliamsonTransforms.jl
@@ -1,0 +1,96 @@
+"""
+    𝒲(X,d)(x)
+
+Computes the Williamson d-transform of the random variable X, taken at point x.
+
+For a univariate non-negative random variable ``X``, with cumulative distribution function ``F`` and an integer ``d\\ge 2``, the Williamson-d-transform of ``X`` is the real function supported on ``[0,\\infty[`` given by:
+
+```math
+\\phi(t) = 𝒲_{d}(X)(t) = \\int_{t}^{\\infty} \\left(1 - \\frac{t}{x}\\right)^{d-1} dF(x) = \\mathbb E\\left( (1 - \\frac{t}{X})^{d-1}_+\\right) \\mathbb 1_{t > 0} + \\left(1 - F(0)\\right)\\mathbb 1_{t <0}
+```
+
+This function has several properties: 
+    - We have that ``\\phi(0) = 1`` and ``\\phi(Inf) = 0``
+    - ``\\phi`` is ``d-2`` times derivable, and the signs of its derivatives alternates : ``\\forall k \\in 0,...,d-2, (-1)^k \\phi^{(k)} \\ge 0``.
+    - ``\\phi^{(d-2)}`` is convex.
+
+These properties makes this function what is called an *archimedean generator*, able to generate *archimedean copulas* in dimensions up to ``d``. 
+
+References: 
+- Williamson, R. E. (1956). Multiply monotone functions and their Laplace transforms. Duke Math. J. 23 189–207. MR0077581
+- McNeil, Alexander J., and Johanna Nešlehová. "Multivariate Archimedean copulas, d-monotone functions and ℓ 1-norm symmetric distributions." (2009): 3059-3097.
+"""
+struct 𝒲{TX, d}
+    X::TX
+    function 𝒲(X::TX, ::Val{d}) where {TX<:Distributions.UnivariateDistribution, d}
+        @assert Base.minimum(X) ≥ 0 && Base.maximum(X) ≤ Inf 
+        @assert d ≥ 2 && isinteger(d) 
+        return new{typeof(X), d}(X)
+    end
+    𝒲(X, d::Int) = 𝒲(X, Val(d))
+end
+function (ϕ::𝒲{TX, d})(x) where {TX,d}
+    x <= 0 && return 1 - Distributions.cdf(ϕ.X,0)
+    return Distributions.expectation(y -> (1 - x/y)^(d-1) * (y > x), ϕ.X)
+end
+
+"""
+    𝒲₋₁(ϕ,d)
+
+
+Computes the inverse Williamson d-transform of the d-monotone archimedean generator ϕ. 
+
+A ``d``-monotone archimedean generator is a function ``\\phi`` on ``\\mathbb R_+`` that has these three properties:
+- ``\\phi(0) = 1`` and ``\\phi(Inf) = 0``
+- ``\\phi`` is ``d-2`` times derivable, and the signs of its derivatives alternates : ``\\forall k \\in 0,...,d-2, (-1)^k \\phi^{(k)} \\ge 0``.
+- ``\\phi^{(d-2)}`` is convex.
+
+For such a function ``\\phi``, the inverse Williamson-d-transform of ``\\phi`` is the cumulative distribution function ``F`` of a non-negative random variable ``X``, defined by : 
+
+```math
+F(x) = 𝒲_{d}^{-1}(\\phi)(x) = 1 - \\frac{(-x)^{d-1} \\phi_+^{(d-1)}(x)}{k!} - \\sum_{k=0}^{d-2} \\frac{(-x)^k \\phi^{(k)}(x)}{k!}
+```
+
+We return this cumulative distribution function in the form of the corresponding random variable `<:Distributions.ContinuousUnivariateDistribution` from `Distributions.jl`. You may then compute : 
+    - The cdf via `Distributions.cdf`
+    - The pdf via `Distributions.pdf` and the logpdf via `Distributions.logpdf`
+    - Samples from the distribution via `rand(X,n)`
+
+References: 
+    - Williamson, R. E. (1956). Multiply monotone functions and their Laplace transforms. Duke Math. J. 23 189–207. MR0077581
+    - McNeil, Alexander J., and Johanna Nešlehová. "Multivariate Archimedean copulas, d-monotone functions and ℓ 1-norm symmetric distributions." (2009): 3059-3097.
+"""
+struct 𝒲₋₁{Tϕ, d} <: Distributions.ContinuousUnivariateDistribution
+    # Woul dprobably be much more efficient if it took the generator and not the function itself. 
+    ϕ::Tϕ
+    function 𝒲₋₁(ϕ, ::Val{d}) where d
+        @assert ϕ(0.0) == 1.0
+        @assert ϕ(float(Inf)) == 0.0
+        @assert isinteger(d)
+        return new{typeof(ϕ),d}(ϕ)
+    end
+    𝒲₋₁(ϕ, d::Int) = 𝒲₋₁(ϕ, Val(d))
+end
+function Distributions.cdf(dist::𝒲₋₁{Tϕ, d}, x) where {Tϕ, d}
+    x ≤ 0 && return zero(x)
+    rez, x_pow = zero(x), one(x)
+    c = taylor(dist.ϕ, x, Val(d-1))
+    for k in 1:d
+        rez += iszero(c[k]) ? 0 : x_pow * c[k]
+        x_pow *= -x
+    end
+    return isnan(rez) ? one(x) : 1 - rez
+end
+
+Distributions.logpdf(dist::𝒲₋₁{Tϕ, d}, x) where {Tϕ, d} = log(max(0, taylor(x -> Distributions.cdf(dist,x), x, Val(1))[end]))
+_quantile(dist::𝒲₋₁, p) = Roots.find_zero(x -> (Distributions.cdf(dist, x) - p), (0.0, Inf))
+Distributions.rand(rng::Distributions.AbstractRNG, dist::𝒲₋₁) = _quantile(dist, rand(rng))
+Base.minimum(::𝒲₋₁) = 0.0
+Base.maximum(::𝒲₋₁) = Inf
+function Distributions.quantile(dist::𝒲₋₁, p::Real)
+    # Validate that p is in the range [0, 1]
+    @assert 0 <= p <= 1
+    return _quantile(dist, p)
+end
+
+

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -12,7 +12,22 @@ _invmono(f; tol=1e-8, θmax=1e6, a=0.0, b=1.0) = begin
     Roots.find_zero(f, (a,b), Roots.Brent(); atol=tol, rtol=tol)
 end
 
+"""
+    taylor(f::F, x₀, ::Val{d}) where {F,d}
 
+Compute the Taylor series expansion of the function `f` around the point `x₀` up to order `d`, and gives you back all the successive derivatives. 
+
+# Arguments
+- `f`: A function to be expanded.
+- `x₀`: The point around which to expand the Taylor series.
+- `d`: The order up to which the Taylor series is computed.
+
+# Returns
+A tuple with value ``(f(x₀), f'(x₀),...,f^{(d)}(x₀))``.
+"""
+function taylor(f::F, x₀, D::Val{d}) where {F,d} 
+    return f(TaylorSeries.Taylor1([x₀, one(x₀)], d)).coeffs
+end
 
 
 """

--- a/test/GenericTests.jl
+++ b/test/GenericTests.jl
@@ -1,6 +1,6 @@
 @testmodule M begin
     using Copulas
-    using HypothesisTests, Distributions, Random, WilliamsonTransforms
+    using HypothesisTests, Distributions, Random
     using InteractiveUtils
     using ForwardDiff
     using StatsBase: corkendall


### PR DESCRIPTION
This branch: 

1) Integrate once and for all in the package the functionalities that was in WilliamsonTransforms.jl
2) Switches back from TaylorDiff to TaylorSeries.jl 

This is a first, very soft version, but since the order of differentiation does not need to be known at compile time for TaylorSeries, a second pass moving it to value-land (i.e. getting rid of the Val{d}() all around) might be beneficial. Let's see how this first one does with the tests