### PR TITLE
Conditioning: carry the conditioning eltype (BigFloat flows end-to-end)

### DIFF
--- a/src/Conditioning.jl
+++ b/src/Conditioning.jl
@@ -4,8 +4,8 @@
 #####  User-facing function: `condition(), rosenblatt(), inverse_rosenblatt()`
 #####
 #####  When implementing new models, you can overwrite: 
-#####   - `DistortionFromCop(C::Copula{d}, js::NTuple{p,Int}, uⱼₛ::NTuple{p,Float64}, i::Int) where {d, p}`
-#####   - `ConditionalCopula(C::Copula{d}, js::NTuple{p,Int}, uⱼₛ::NTuple{p,Float64}) where {d, p}`
+#####   - `DistortionFromCop(C::Copula{d}, js::NTuple{p,Int}, uⱼₛ::NTuple{p,<:Real}, i::Int) where {d, p}`
+#####   - `ConditionalCopula(C::Copula{d}, js::NTuple{p,Int}, uⱼₛ::NTuple{p,<:Real}) where {d, p}`
 ###############################################################################
 
 # A few utilities : 
@@ -102,21 +102,19 @@ Notes
 - A convenience method `DistortionFromCop(C, j::Int, uj::Real, i::Int)` exists for
     the common `p = 1` case.
 """
-struct DistortionFromCop{TC,p}<:Distortion
+struct DistortionFromCop{TC,p,T}<:Distortion
     C::TC
     i::Int
     js::NTuple{p,Int}
-    uⱼₛ::NTuple{p,Float64}
-    den::Float64
+    uⱼₛ::NTuple{p,T}
+    den::T
     function DistortionFromCop(C::Copula{D}, js, uⱼₛ, i) where {D}
         jst, uⱼₛt = _process_tuples(Val{D}(), js, uⱼₛ)
         p = length(jst)
-        if p==1
-            den = Distributions.pdf(subsetdims(C, jst), uⱼₛt[1])
-        else
-            den = Distributions.pdf(subsetdims(C, jst), collect(uⱼₛt))
-        end
-        return new{typeof(C), p}(C, i, jst, uⱼₛt, den)
+        den = p==1 ? Distributions.pdf(subsetdims(C, jst), uⱼₛt[1]) :
+                     Distributions.pdf(subsetdims(C, jst), collect(uⱼₛt))
+        T = promote_type(eltype(uⱼₛt), typeof(den))
+        return new{typeof(C), p, T}(C, i, jst, NTuple{p,T}(uⱼₛt), T(den))
     end
 end
 Distributions.cdf(d::DistortionFromCop, u::Real) = _partial_cdf(d.C, (d.i,), d.js, (u,), d.uⱼₛ) / d.den
@@ -145,12 +143,12 @@ end
 
 Copula of the conditioned random vector U_I | U_J = u_J.
 """
-struct ConditionalCopula{d, D, p, TDs}<:Copula{d}
+struct ConditionalCopula{d, D, p, T, TDs}<:Copula{d}
     C::Copula{D}
     js::NTuple{p, Int}
     is::NTuple{d, Int}
-    uⱼₛ::NTuple{p, Float64}
-    den::Float64
+    uⱼₛ::NTuple{p, T}
+    den::T
     distortions::TDs
     function ConditionalCopula(C::Copula{D}, js, uⱼₛ) where {D}
         jst, uⱼₛt = _process_tuples(Val{D}(), js, uⱼₛ)
@@ -158,12 +156,10 @@ struct ConditionalCopula{d, D, p, TDs}<:Copula{d}
         p = length(jst)
         d = D - p
         distos = Tuple(DistortionFromCop(C, jst, uⱼₛt, i) for i in ist)
-                if p==1
-            den = Distributions.pdf(subsetdims(C, jst), uⱼₛt[1])
-        else
-            den = Distributions.pdf(subsetdims(C, jst), collect(uⱼₛt))
-        end
-        return new{d, D, p, typeof(distos)}(C, jst, ist, uⱼₛt, den, distos)
+        den = p==1 ? Distributions.pdf(subsetdims(C, jst), uⱼₛt[1]) :
+                     Distributions.pdf(subsetdims(C, jst), collect(uⱼₛt))
+        T = promote_type(eltype(uⱼₛt), typeof(den))
+        return new{d, D, p, T, typeof(distos)}(C, jst, ist, NTuple{p,T}(uⱼₛt), T(den), distos)
     end
 end
 function _cdf(CC::ConditionalCopula{d,D,p,T}, v::AbstractVector{<:Real}) where {d,D,p,T}
@@ -258,7 +254,7 @@ end
 ###########################################################################
 
 
-function DistortionFromCop(S::SubsetCopula, js::NTuple{p,Int}, uⱼₛ::NTuple{p,Float64}, i::Int) where {p}
+function DistortionFromCop(S::SubsetCopula, js::NTuple{p,Int}, uⱼₛ::NTuple{p,<:Real}, i::Int) where {p}
     ibase = S.dims[i]
     jsbase = ntuple(k -> S.dims[js[k]], p)
     return DistortionFromCop(S.C, jsbase, uⱼₛ, ibase)

--- a/test/ConditionalDistribution.jl
+++ b/test/ConditionalDistribution.jl
@@ -333,3 +333,28 @@ end
     # Float32 also previously recursed; confirm it is accepted too.
     @test condition(C3, (1, 2), (0.3f0, 0.4f0)) isa Copulas.Distortion
 end
+
+@testset "conditioning carries the conditioning eltype (BigFloat flows end-to-end)" begin
+    # condition() accepts non-Float64 values, AND the conditioning point now
+    # survives into the ConditionalCopula/DistortionFromCop (no Float64 downcast),
+    # so BigFloat precision flows through to the conditional CDF.
+    C = ClaytonCopula(4, 2.0)
+    xf = [0.3, 0.5, 0.4, 0.6]; xb = big.(xf)
+
+    # single-conditioned distortion (p = d-1): the conditional marginal of coord 2
+    df = condition(C, (1, 3, 4), Tuple(xf[[1, 3, 4]]))
+    db = condition(C, (1, 3, 4), Tuple(xb[[1, 3, 4]]))
+    @test db isa Copulas.DistortionFromCop
+    @test db.den isa BigFloat                 # value type flows INTO the struct
+    @test eltype(db.uⱼₛ) === BigFloat
+    @test cdf(db, xb[2]) isa BigFloat          # ... and OUT through the conditional CDF
+    @test Float64(cdf(db, xb[2])) ≈ cdf(df, xf[2]) atol = 1e-9
+
+    # multi-conditioned ConditionalCopula (p < d-1)
+    mb = condition(C, (1, 3), Tuple(xb[[1, 3]]))
+    @test mb.C isa Copulas.ConditionalCopula
+    @test mb.C.den isa BigFloat
+    @test cdf(mb, xb[[2, 4]]) isa BigFloat
+    @test Float64(cdf(mb, xb[[2, 4]])) ≈
+          cdf(condition(C, (1, 3), Tuple(xf[[1, 3]])), xf[[2, 4]]) atol = 1e-9
+end


### PR DESCRIPTION
#368 loosened `condition()` to accept any `<:Real` conditioning point, but the `ConditionalCopula` and `DistortionFromCop` structs still stored `uⱼₛ`/`den` as `Float64` — so a `BigFloat` (or `Float32`, `Double64`, …) point is silently **downcast** to `Float64`, and the conditional CDF can't carry that precision.

This parametrises both structs on a value type `T`, inferred from the conditioning eltype:

- `DistortionFromCop{TC,p}` → `DistortionFromCop{TC,p,T}` — fields `uⱼₛ::NTuple{p,T}`, `den::T`
- `ConditionalCopula{d,D,p,TDs}` → `ConditionalCopula{d,D,p,T,TDs}` — same

The algorithms (`_assemble`, `_swap`, `_partial_cdf`, `_process_tuples`) are already eltype-generic, so the struct fields were the only thing pinning precision. **Backward-compatible**: `Float64` inputs give `T=Float64`, behaviour byte-identical.

Result: precision flows through `den` and the conditional CDF end-to-end wherever the parent copula's `pdf`/`cdf` support it (e.g. Clayton/Archimedean). It's also what high-precision nested-Archimedean censored likelihoods need.

Adds a test asserting the conditional CDF is `BigFloat`-**typed** (not merely accepted — which #368 already covered), for both the single-distortion and `ConditionalCopula` paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
