### PR TITLE
add derivates for extreme value copulas

### DIFF
--- a/src/ExtremeValueCopula.jl
+++ b/src/ExtremeValueCopula.jl
@@ -9,7 +9,7 @@ Extreme-value copulas model tail dependence via a stable tail dependence functio
 via a Pickands dependence function ``A``. In any dimension ``d``, the copula cdf is
 
 ```math
-\\displaystyle C(u) = \\\exp\\!\\left(-\\, \\\ell(-\\log u_1,\\ldots,-\\log u_d) \\right).
+\\displaystyle C(u) = \\exp\\!\\left(-\\, \\ell(-\\log u_1,\\ldots,-\\log u_d) \\right).
 ```
 
 For ``d=2``, write ``x=-\\log u``, ``y=-\\log v``, ``s=x+y``, and ``t = x/s``. The relation between ``\\ell`` and ``A`` is

--- a/src/Tail/AsymGalambosTail.jl
+++ b/src/Tail/AsymGalambosTail.jl
@@ -65,3 +65,55 @@ function A(tail::AsymGalambosTail, t::Real)
     s  = LogExpFunctions.logaddexp(x1, x2) / α
     return -LogExpFunctions.expm1(-s)
 end
+
+function dA(tail::AsymGalambosTail, t::Real)
+    tt = _safett(t)
+    α, θ₁, θ₂ = tail.α, tail.θ₁, tail.θ₂
+
+    α == 0 || (θ₁ == 0 && θ₂ == 0) && return one(tt)
+
+    a = tt
+    b = 1 - tt
+
+    x1 = -α * log(θ₁ * a)
+    x2 = -α * log(θ₂ * b)
+
+    ℓ = LogExpFunctions.logaddexp(x1, x2)
+
+    w1 = exp(x1 - ℓ)
+    w2 = exp(x2 - ℓ)
+
+    B = exp(-ℓ / α)
+
+    return B * (w2 / b - w1 / a)
+end
+
+function d²A(tail::AsymGalambosTail, t::Real)
+    tt = _safett(t)
+    α, θ₁, θ₂ = tail.α, tail.θ₁, tail.θ₂
+
+    α == 0 || (θ₁ == 0 && θ₂ == 0) && return one(tt)
+
+    a = tt
+    b = 1 - tt
+
+    x1 = -α * log(θ₁ * a)
+    x2 = -α * log(θ₂ * b)
+
+    ℓ = LogExpFunctions.logaddexp(x1, x2)
+
+    w1 = exp(x1 - ℓ)
+    w2 = exp(x2 - ℓ)
+
+    B = exp(-ℓ / α)
+
+    inva = inv(a)
+    invb = inv(b)
+
+    g = w2 * invb - w1 * inva
+
+    term1 = w2 * invb^2 + w1 * inva^2
+    term2 = g^2
+
+    return (1 + α) * B * (term1 - term2)
+end

--- a/src/Tail/AsymLogTail.jl
+++ b/src/Tail/AsymLogTail.jl
@@ -57,3 +57,41 @@ function A(tail::AsymLogTail, t::Real)
     θ₁, θ₂ = tail.θ₁, tail.θ₂
     return ((θ₁^α) * (1-tt)^α + (θ₂^α) * tt^α)^(1/α) + (θ₁ - θ₂)*tt + 1 - θ₁
 end
+
+function dA(tail::AsymLogTail, t::Real)
+    tt = _safett(t)
+    α, θ₁, θ₂ = tail.α, tail.θ₁, tail.θ₂
+
+    (θ₁ == 0 && θ₂ == 0) && return zero(tt)
+
+    a = tt
+    b = 1 - tt
+
+    c1 = θ₁^α
+    c2 = θ₂^α
+
+    R = c1 * b^α + c2 * a^α
+    D = c2 * a^(α - 1) - c1 * b^(α - 1)
+
+    return R^(inv(α) - 1) * D + θ₁ - θ₂
+end
+
+function d²A(tail::AsymLogTail, t::Real)
+    tt = _safett(t)
+    α, θ₁, θ₂ = tail.α, tail.θ₁, tail.θ₂
+
+    (θ₁ == 0 && θ₂ == 0) && return zero(tt)
+    α == 1 && return zero(tt)
+
+    a = tt
+    b = 1 - tt
+
+    c1 = θ₁^α
+    c2 = θ₂^α
+
+    R = c1 * b^α + c2 * a^α
+    D = c2 * a^(α - 1) - c1 * b^(α - 1)
+    E = c2 * a^(α - 2) + c1 * b^(α - 2)
+
+    return (α - 1) * R^(inv(α) - 2) * (R * E - D^2)
+end

--- a/src/Tail/AsymMixedTail.jl
+++ b/src/Tail/AsymMixedTail.jl
@@ -128,3 +128,16 @@ function A(tail::AsymMixedTail, t::Real)
     return θ₂*tt^3 + θ₁*tt^2 - (θ₁+θ₂)*tt + 1
 end
 
+function dA(tail::AsymMixedTail, t::Real)
+    tt = _safett(t)
+    θ₁, θ₂ = tail.θ₁, tail.θ₂
+
+    return 3θ₂ * tt^2 + 2θ₁ * tt - (θ₁ + θ₂)
+end
+
+function d²A(tail::AsymMixedTail, t::Real)
+    tt = _safett(t)
+    θ₁, θ₂ = tail.θ₁, tail.θ₂
+
+    return 6θ₂ * tt + 2θ₁
+end

--- a/src/Tail/MixedTail.jl
+++ b/src/Tail/MixedTail.jl
@@ -47,6 +47,19 @@ _θ_bounds(::Type{<:MixedTail}, d) = (0.0, 1.0)
 
 A(tail::MixedTail, t::Real) = tail.θ * t^2 - tail.θ * t + 1
 
+function dA(tail::MixedTail, t::Real)
+    tt = _safett(t)
+    θ = tail.θ
+
+    return θ * (2tt - 1)
+end
+
+function d²A(tail::MixedTail, t::Real)
+    θ = tail.θ
+
+    return 2θ
+end
+
 _tau_Mixed(θ; kw...) = θ ≤ 0 ? 0.0 : θ ≥ 1 ? 1.0 : 1 + 4 * QuadGK.quadgk(t -> ((2θ*t - θ) / (θ*t^2 - θ*t + 1)) * t * (1-t), 0, 1; kw...)[1]
 _rho_Mixed(θ; kw...) = θ ≤ 0 ? 0.0 : θ ≥ 1 ? 1.0 : 12 * QuadGK.quadgk(t -> inv((θ*t^2 - θ*t + 1 + 1)^2), 0, 1; kw...)[1] - 3
 

--- a/test/GenericTests.jl
+++ b/test/GenericTests.jl
@@ -766,7 +766,7 @@ Bestiary = filter(GenericTestFilter, Bestiary)
         @testif (spe.dA || spe.d²A || spe._A_dA_d²A || spe.ℓ) "Testing ℓ and cdf for Extreme Value Copula" begin 
             u, v = rand(rng), rand(rng)
             x, y = -log(u), -log(v)
-            s = y / (x + y)
+            s = x / (x + y)
             expected_ℓ = Copulas.A(C.tail, s) * (x + y)
             @test isapprox(Copulas.ℓ(C.tail, (x, y)), expected_ℓ; atol=0.1)
             expected_cdf = exp(-expected_ℓ)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,7 +19,7 @@ testfiles = [
 ]
 
 # You can override the definition of this GenericTestFilter if you want. 
-GenericTestFilter(C) = true
+GenericTestFilter(C) = true # the default value lets every copula go through. 
 
 # An example: 
 # GenericTestFilter(C) = C isa BC2Copula || C isa MOCopula || C isa CuadrasAugeCopula # || C isa GumbelCopula # You can filter on your model. 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,7 +19,7 @@ testfiles = [
 ]
 
 # You can override the definition of this GenericTestFilter if you want. 
-GenericTestFilter(C) = true # the default value lets every copula go through. 
+GenericTestFilter(C) = C isa Copulas.ExtremeValueCopula
 
 # An example: 
 # GenericTestFilter(C) = C isa BC2Copula || C isa MOCopula || C isa CuadrasAugeCopula # || C isa GumbelCopula # You can filter on your model. 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,7 +19,7 @@ testfiles = [
 ]
 
 # You can override the definition of this GenericTestFilter if you want. 
-GenericTestFilter(C) = C isa Copulas.ExtremeValueCopula
+GenericTestFilter(C) = true
 
 # An example: 
 # GenericTestFilter(C) = C isa BC2Copula || C isa MOCopula || C isa CuadrasAugeCopula # || C isa GumbelCopula # You can filter on your model. 


### PR DESCRIPTION
This PR adds analytical implementations of dA and d²A for some bivariate extreme value tails: 

- AsymGalambosTail
- AsymLogTail
- AsymMixedTail
- MixedTail

The Tails, such as BC2Tail, MOTail and CuadrasAugeTail, continue to use ForwardDiff, since their Pickands functions are only partly differentiable.

While testing, I also found a small bug in GenericTests.jl for asymmetric extreme-value tails. The test for ℓ used ``s = y / (x + y)``, but the Tail2 interface defines ``A(tail, (u,v)) = A(tail, u)``. Therefore ``ℓ(x,y) = (x+y)A(x/(x+y))``, so the test was updated to use ``s = x / (x + y)``.

All package tests pass locally.