### PR TITLE
Fix Roots 3 quantile failures

### DIFF
--- a/src/Conditioning.jl
+++ b/src/Conditioning.jl
@@ -55,6 +55,28 @@ the original scale: if `D::Distortion` and `X::UnivariateDistribution`, then `D(
 is the distribution of `X_i | U_J = u_J`.
 """
 abstract type Distortion<:Distributions.ContinuousUnivariateDistribution end
+
+function _unit_quantile(d, p::Real)
+    T = typeof(float(p))
+    zero(T) <= p <= one(T) || throw(ArgumentError("p must be between 0 and 1"))
+    p == zero(T) && return zero(T)
+    p == one(T) && return one(T)
+
+    lo, hi = zero(T), one(T)
+    Distributions.cdf(d, lo) >= p && return lo
+    Distributions.cdf(d, hi) < p && return hi
+    for _ in 1:precision(T)
+        mid = (lo + hi) / 2
+        (mid == lo || mid == hi) && break
+        if Distributions.cdf(d, mid) >= p
+            hi = mid
+        else
+            lo = mid
+        end
+    end
+    return hi
+end
+
 (D::Distortion)(::Distributions.Uniform) = D
 (D::Distortion)(X::Distributions.UnivariateDistribution) = DistortedDist(D, X)
 Distributions.minimum(::Distortion) = 0.0

--- a/src/MiscellaneousCopulas/BernsteinCopula.jl
+++ b/src/MiscellaneousCopulas/BernsteinCopula.jl
@@ -153,9 +153,17 @@ function Distributions._rand!(rng::Distributions.AbstractRNG, B::BernsteinCopula
     return u
 end
 
+struct BernsteinDistortion{M} <: Distortion
+    mixture::M
+end
+Distributions.cdf(d::BernsteinDistortion, u::Real) = Distributions.cdf(d.mixture, u)
+Distributions.logcdf(d::BernsteinDistortion, u::Real) = Distributions.logcdf(d.mixture, u)
+Distributions.pdf(d::BernsteinDistortion, u::Real) = Distributions.pdf(d.mixture, u)
+Distributions.logpdf(d::BernsteinDistortion, u::Real) = Distributions.logpdf(d.mixture, u)
+Distributions.quantile(d::BernsteinDistortion, p::Real) = _unit_quantile(d, p)
+
 function DistortionFromCop(B::BernsteinCopula{D}, js::NTuple{p,Int}, uⱼₛ::NTuple{p,Float64}, i::Int) where {D,p}
     # Build mixture weights over s_i given fixed u_J for J = js.
-    # Return a MixtureModel(Beta...) directly (Distortion call will push-forward marginals).
     Iset = Tuple(setdiff(1:D, js))
     @assert i in Iset "i must refer to a non-conditioned coordinate"
     m = B.m
@@ -179,7 +187,7 @@ function DistortionFromCop(B::BernsteinCopula{D}, js::NTuple{p,Int}, uⱼₛ::NT
     end
     α ./= sα
     comps = [Distributions.Beta(k, mi - (k - 1)) for k in 1:mi]
-    return Distributions.MixtureModel(comps, α)
+    return BernsteinDistortion(Distributions.MixtureModel(comps, α))
 end
 
 # Fitting colocated. 

--- a/src/UnivariateDistribution/ExtremeDist.jl
+++ b/src/UnivariateDistribution/ExtremeDist.jl
@@ -14,33 +14,7 @@ function _pdf(d::ExtremeDist, z)
 end
 
 function Distributions.quantile(d::ExtremeDist, p)
-    p < 0 || p > 1 && throw(ArgumentError("p must be between 0 and 1"))
-    # Automatically decide whether to use binary search or Brent
-    if needs_binary_search(d.tail)
-        # Use binary search for copulas with large parameters     
-        lower_bound = eps()
-        upper_bound = 1.0 - eps()
-        mid_point = (lower_bound + upper_bound) / 2
-
-        while upper_bound - lower_bound > 1e-6  # Accuracy threshold
-            mid_value = Distributions.cdf(d, mid_point) - p
-
-            if abs(mid_value) < 1e-6
-                return mid_point
-            elseif mid_value > 0
-                upper_bound = mid_point
-            else
-                lower_bound = mid_point
-            end
-
-            mid_point = (lower_bound + upper_bound) / 2
-        end
-
-        return mid_point
-    else
-        # Use Brent for other copulations or if there are no problems
-        return Roots.find_zero(x -> Distributions.cdf(d, x) - p, (eps(), 1.0 - eps()), Roots.Brent())
-    end
+    return _unit_quantile(d, p)
 end
 
 # Generate random samples from the radial distribution using the quantile function

--- a/test/ConditionalDistribution.jl
+++ b/test/ConditionalDistribution.jl
@@ -297,6 +297,17 @@ end
     @test all(0 .<= quantile.(Ref(D), (0.2, 0.5, 0.8)) .<= 1)
 end
 
+@testset "Bernstein distortion quantiles use bounded bisection" begin
+    C = BernsteinCopula(GaussianCopula(2, 0.3); m=5)
+    D = condition(C, (1,), (0.4,))
+    @test D isa Copulas.BernsteinDistortion
+    for p in (0.1, 0.5, 0.9)
+        q = quantile(D, p)
+        @test 0 <= q <= 1
+        @test cdf(D, q) ≈ p atol = 2e-12
+    end
+end
+
 @testset "Generic Distortion vs AD (bivariate small subset)" begin
     # Compare the GENERIC DistortionFromCop (forced via @invoke) against AD-based reference
     # on a tiny, fast subset to validate the generic path independent of family specifics.

--- a/test/MiscelaneousCopulas.jl
+++ b/test/MiscelaneousCopulas.jl
@@ -1,4 +1,19 @@
 
+@testset "Extreme-value quantiles use bounded bisection" begin
+    for C in (
+        BC2Copula(2, 0.5, 0.3),
+        BC2Copula(2, 0.5516353577049822, 0.33689370624999193),
+        BC2Copula(2, 0.6, 0.8),
+    )
+        D = Copulas.ExtremeDist(C.tail)
+        for p in (0.1, 0.5, 0.9)
+            q = quantile(D, p)
+            @test 0 <= q <= 1
+            @test cdf(D, q) >= p
+        end
+    end
+end
+
 @testset "Testing survival stuff" begin
     # [GenericTests integration]: Yes. Symmetry of survival transformations on pdf/cdf is generic; we can add survival invariance checks.
     Random.seed!(rng,123)


### PR DESCRIPTION
## Summary

- replace `ExtremeDist` root finding with bounded generalized-inverse bisection on `[0, 1]`
- wrap Bernstein conditional beta mixtures in a distortion with the same robust quantile path
- add targeted BC2 and Bernstein regression tests

This avoids the Roots 3 convergence and bracketing behavior described in #375 while correctly handling discontinuous CDFs.

Closes #375

> This PR description and the implementation were prepared with assistance from an LLM and should be reviewed accordingly.