### PR TITLE
Default copulas to matrix samplers

### DIFF
--- a/docs/src/manual/developer_guide.md
+++ b/docs/src/manual/developer_guide.md
@@ -71,20 +71,23 @@ function Distributions._logpdf(C::MyCopula, u)
     # You can safely assume u to be an abstract vector of the right length and inside the hypercube.
     # Return the logpdf value on u
 end
-function Distributions._rand!(rng::Distributions.AbstractRNG, C::MyCopula, u::AbstractVector{<:Real})
-    # You need to fill the vector u (of lenght d) with a random sample, and then return it. 
-    return u
+function Distributions._rand!(rng::Distributions.AbstractRNG, C::MyCopula, U::AbstractMatrix{<:Real})
+    # Fill the d × n matrix U with n samples, stored column-wise, and return it.
+    return U
 end 
 ```
 
 Once defined, these automatically integrate with the `Copulas.jl` and `Distributions.jl` interface.
 
-!!! info "Matrix sampler"
-    For performance reasons, you can also implement a matrix sampler if you feel its necessary: 
+!!! info "Sampling contract"
+    The matrix sampler is the required primitive. The generic vector sampler presents its
+    output as a `d × 1` matrix and delegates to it, so implementing a vector method is never
+    required for correctness. A family may still provide a vector specialization when
+    benchmarks show that its scalar setup cost matters:
     ```julia
-    function Distributions._rand!(rng::Distributions.AbstractRNG,C::MyCopula, U::DenseMatrix{<:Real})
-        # You need to fill the matrix u (of shape (d,n)) with n random samples, and then return it.
-        return U
+    function Distributions._rand!(rng::Distributions.AbstractRNG, C::MyCopula, u::AbstractVector{<:Real})
+        # Optional performance specialization for one sample.
+        return u
     end
     ```
 
@@ -403,21 +406,23 @@ Instead, we define a sampling rule that randomly selects between three dependenc
 ```@example generic_copula_example
 Distributions._logpdf(C::MardiaCopula, u) = NaN
 
-function Distributions._rand!(rng::Distributions.AbstractRNG, C::MardiaCopula, x::AbstractVector{T}) where {T<:Real}
+function Distributions._rand!(rng::Distributions.AbstractRNG, C::MardiaCopula, X::AbstractMatrix{T}) where {T<:Real}
     θ = C.θ
-    u1, u2 = rand(rng, Distributions.Uniform(0,1), 2)
     p = [θ^2 * (1 + θ) / 2, 1 - θ^2, θ^2 * (1 - θ) / 2]
-    z = rand(rng, Distributions.Categorical(p))
-    if z == 1
-        u = min(u1, u2)
-        x[1] = u; x[2] = u
-    elseif z == 2
-        x[1] = u1; x[2] = u2
-    else
-        u = max(u1 + u2 - 1, 0)
-        x[1] = u; x[2] = 1 - u
+    for j in axes(X, 2)
+        u1, u2 = rand(rng, Distributions.Uniform(0,1), 2)
+        z = rand(rng, Distributions.Categorical(p))
+        if z == 1
+            u = min(u1, u2)
+            X[1, j] = u; X[2, j] = u
+        elseif z == 2
+            X[1, j] = u1; X[2, j] = u2
+        else
+            u = max(u1 + u2 - 1, 0)
+            X[1, j] = u; X[2, j] = 1 - u
+        end
     end
-    return x
+    return X
 end
 ```
 
@@ -712,4 +717,3 @@ M
     EV copulas usually lack smooth closed-form densities.
     Analytical forms are optional but highly recommended to improve numerical stability.
     Otherwise, `Copulas.jl` will fall back to numerical integration based on the Pickands function.
-

--- a/src/ArchimaxCopula.jl
+++ b/src/ArchimaxCopula.jl
@@ -204,20 +204,13 @@ end
 
 # Use the matrix sampler for better efficiency
 # (if not working, maybe uncomment the vetor version ?)
-function Distributions._rand!(rng::Distributions.AbstractRNG, C::ArchimaxCopula{2, TG, TT}, A::DenseMatrix{T}) where {T<:Real, TG, TT}
+function Distributions._rand!(rng::Distributions.AbstractRNG, C::ArchimaxCopula{2, TG, TT}, A::AbstractMatrix{T}) where {T<:Real, TG, TT}
     evcop, frail = ExtremeValueCopula(2, C.tail), frailty(C.gen)
     Distributions._rand!(rng, evcop, A)
     F = zeros(eltype(A), size(A, 2))
     Distributions.rand!(rng, frail, F)
     A .= ϕ.(C.gen, -log.(A) ./ F') 
     return A
-end
-function Distributions._rand!(rng::Distributions.AbstractRNG, C::ArchimaxCopula{2, TG, TT}, x::AbstractVector{T}) where {T<:Real, TG, TT}
-    v1, v2 = rand(rng, ExtremeValueCopula(2, C.tail))
-    M  = rand(rng, frailty(C.gen))
-    x[1] = ϕ(C.gen, -log(v1)/M)
-    x[2] = ϕ(C.gen, -log(v2)/M)
-    return x
 end
 
 

--- a/src/ArchimedeanCopula.jl
+++ b/src/ArchimedeanCopula.jl
@@ -77,22 +77,29 @@ function Distributions._logpdf(C::ArchimedeanCopula{d,TG}, u) where {d,TG}
     end
     return log(max(ϕ⁽ᵏ⁾(C.G, d, sum(ϕ⁻¹.(C.G, u))) * prod(ϕ⁻¹⁽¹⁾.(C.G, u)), 0))
 end
-function Distributions._rand!(rng::Distributions.AbstractRNG, C::ArchimedeanCopula{d, TG}, x::AbstractVector{T}) where {T<:Real, d, TG}
-    # By default, we use the Williamson sampling.
-    Random.randexp!(rng,x)
-    r = rand(rng, 𝒲₋₁(C.G, d))
-    sx = sum(x)
-    for i in 1:length(C)
-        x[i] = ϕ(C.G,r * x[i]/sx)
+function Distributions._rand!(rng::Distributions.AbstractRNG, C::ArchimedeanCopula{d, TG}, A::AbstractMatrix{T}) where {T<:Real, d, TG}
+    size(A, 1) == d || throw(ArgumentError("Dimension mismatch between copula and output matrix"))
+    Random.randexp!(rng, A)
+    R = 𝒲₋₁(C.G, d)
+    radii = rand(rng, R, size(A, 2))
+    @inbounds for (j, col) in enumerate(axes(A, 2))
+        sx = sum(view(A, :, col))
+        r = radii[j]
+        for row in axes(A, 1)
+            A[row, col] = ϕ(C.G, r * A[row, col] / sx)
+        end
     end
-    return x
+    return A
 end
-function Distributions._rand!(rng::Distributions.AbstractRNG, C::ArchimedeanCopula{d, GT}, x::AbstractVector{T}) where {T<:Real, d, GT<:AbstractFrailtyGenerator}
+function Distributions._rand!(rng::Distributions.AbstractRNG, C::ArchimedeanCopula{d, GT}, A::AbstractMatrix{T}) where {T<:Real, d, GT<:AbstractFrailtyGenerator}
+    size(A, 1) == d || throw(ArgumentError("Dimension mismatch between copula and output matrix"))
     F = frailty(C.G)
-    Random.randexp!(rng, x)
-    f = rand(rng, F)
-    x .= ϕ.(C.G, x ./ f)
-    return x
+    Random.randexp!(rng, A)
+    frailties = rand(rng, F, size(A, 2))
+    @inbounds for (j, col) in enumerate(axes(A, 2)), row in axes(A, 1)
+        A[row, col] = ϕ(C.G, A[row, col] / frailties[j])
+    end
+    return A
 end
 
 generatorof(b::Type{<:ArchimedeanCopula}) = fieldtype(b, :G)

--- a/src/ArchimedeanCopula.jl
+++ b/src/ArchimedeanCopula.jl
@@ -79,15 +79,12 @@ function Distributions._logpdf(C::ArchimedeanCopula{d,TG}, u) where {d,TG}
 end
 function Distributions._rand!(rng::Distributions.AbstractRNG, C::ArchimedeanCopula{d, TG}, A::AbstractMatrix{T}) where {T<:Real, d, TG}
     size(A, 1) == d || throw(ArgumentError("Dimension mismatch between copula and output matrix"))
-    Random.randexp!(rng, A)
     R = 𝒲₋₁(C.G, d)
-    radii = Vector{T}(undef, size(A, 2))
-    @inbounds for j in eachindex(radii)
-        radii[j] = rand(rng, R)
-    end
-    @inbounds for (j, col) in enumerate(axes(A, 2))
-        sx = sum(view(A, :, col))
-        r = radii[j]
+    @inbounds for col in axes(A, 2)
+        sample = view(A, :, col)
+        Random.randexp!(rng, sample)
+        r = rand(rng, R)
+        sx = sum(sample)
         for row in axes(A, 1)
             A[row, col] = ϕ(C.G, r * A[row, col] / sx)
         end
@@ -97,13 +94,13 @@ end
 function Distributions._rand!(rng::Distributions.AbstractRNG, C::ArchimedeanCopula{d, GT}, A::AbstractMatrix{T}) where {T<:Real, d, GT<:AbstractFrailtyGenerator}
     size(A, 1) == d || throw(ArgumentError("Dimension mismatch between copula and output matrix"))
     F = frailty(C.G)
-    Random.randexp!(rng, A)
-    frailties = Vector{T}(undef, size(A, 2))
-    @inbounds for j in eachindex(frailties)
-        frailties[j] = rand(rng, F)
-    end
-    @inbounds for (j, col) in enumerate(axes(A, 2)), row in axes(A, 1)
-        A[row, col] = ϕ(C.G, A[row, col] / frailties[j])
+    @inbounds for col in axes(A, 2)
+        sample = view(A, :, col)
+        Random.randexp!(rng, sample)
+        frailty = rand(rng, F)
+        for row in axes(A, 1)
+            A[row, col] = ϕ(C.G, A[row, col] / frailty)
+        end
     end
     return A
 end

--- a/src/ArchimedeanCopula.jl
+++ b/src/ArchimedeanCopula.jl
@@ -81,7 +81,10 @@ function Distributions._rand!(rng::Distributions.AbstractRNG, C::ArchimedeanCopu
     size(A, 1) == d || throw(ArgumentError("Dimension mismatch between copula and output matrix"))
     Random.randexp!(rng, A)
     R = 𝒲₋₁(C.G, d)
-    radii = rand(rng, R, size(A, 2))
+    radii = Vector{T}(undef, size(A, 2))
+    @inbounds for j in eachindex(radii)
+        radii[j] = rand(rng, R)
+    end
     @inbounds for (j, col) in enumerate(axes(A, 2))
         sx = sum(view(A, :, col))
         r = radii[j]
@@ -95,7 +98,10 @@ function Distributions._rand!(rng::Distributions.AbstractRNG, C::ArchimedeanCopu
     size(A, 1) == d || throw(ArgumentError("Dimension mismatch between copula and output matrix"))
     F = frailty(C.G)
     Random.randexp!(rng, A)
-    frailties = rand(rng, F, size(A, 2))
+    frailties = Vector{T}(undef, size(A, 2))
+    @inbounds for j in eachindex(frailties)
+        frailties[j] = rand(rng, F)
+    end
     @inbounds for (j, col) in enumerate(axes(A, 2)), row in axes(A, 1)
         A[row, col] = ϕ(C.G, A[row, col] / frailties[j])
     end

--- a/src/Conditioning.jl
+++ b/src/Conditioning.jl
@@ -219,22 +219,24 @@ function Distributions._logpdf(CC::ConditionalCopula{d,D,p,T,TDs}, v::AbstractVe
 end
 
 # Sampling: sequential inverse-CDF using conditional distortions
-function Distributions._rand!(rng::Distributions.AbstractRNG, CC::ConditionalCopula{d, D, p}, x::AbstractVector{T}) where {T<:Real, d, D, p}
+function Distributions._rand!(rng::Distributions.AbstractRNG, CC::ConditionalCopula{d, D, p}, A::AbstractMatrix{T}) where {T<:Real, d, D, p}
+    size(A, 1) == d || throw(ArgumentError("Dimension mismatch between copula and output matrix"))
     # We want a sample from the COPULA of the conditional model. Let U be a
     # draw from the conditional joint H_{I|J}(· | u_J). The corresponding
     # copula coordinates are V_k = F_{i_k|J}(U_k | u_J) = cdf(distortions[k], U_k).
     # Sample U sequentially by conditioning on J ∪ previously sampled I.
-    J = [j for j in CC.js]
-    ujs =  [u for u in CC.uⱼₛ]
-    for k in 1:d
-        iₖ = CC.is[k]
-        uₖ = rand(rng, DistortionFromCop(CC.C, Tuple(J), Tuple(ujs), iₖ))
-        xₖ = Distributions.cdf(CC.distortions[k], uₖ)
-        x[k] = xₖ
-        push!(J, iₖ)
-        push!(ujs, uₖ)
+    for col in axes(A, 2)
+        J = [j for j in CC.js]
+        ujs = [u for u in CC.uⱼₛ]
+        for k in 1:d
+            iₖ = CC.is[k]
+            uₖ = rand(rng, DistortionFromCop(CC.C, Tuple(J), Tuple(ujs), iₖ))
+            A[k, col] = Distributions.cdf(CC.distortions[k], uₖ)
+            push!(J, iₖ)
+            push!(ujs, uₖ)
+        end
     end
-    return x
+    return A
 end
 
 ###########################################################################

--- a/src/Copula.jl
+++ b/src/Copula.jl
@@ -8,11 +8,17 @@
 #####       3) pseudo(data) construct pseudo-data from a given dataset.  
 #####
 #####  When implementing a new copula, you have to overwrite `Copulas._cdf()`
+#####  and `Distributions._rand!()` for matrix inputs.
 #####  and you may overwrite ρ, τ, β, γ, ι, λₗ, λᵤ, measure for performances. 
 ###############################################################################
 abstract type Copula{d} <: Distributions.ContinuousMultivariateDistribution end
 Base.broadcastable(C::Copula) = Ref(C)
 Base.length(::Copula{d}) where d = d
+function Distributions._rand!(rng::Distributions.AbstractRNG, C::Copula{d}, x::AbstractVector{T}) where {d,T<:Real}
+    length(x) == d || throw(ArgumentError("Dimension mismatch between copula and output vector"))
+    Distributions._rand!(rng, C, reshape(x, d, 1))
+    return x
+end
 function Distributions.cdf(C::Copula{d},u::VT) where {d,VT<:AbstractVector}
     length(u) != d && throw(ArgumentError("Dimension mismatch between copula and input vector"))
     if any(iszero,u)

--- a/src/Copula.jl
+++ b/src/Copula.jl
@@ -19,6 +19,9 @@ function Distributions._rand!(rng::Distributions.AbstractRNG, C::Copula{d}, x::A
     Distributions._rand!(rng, C, reshape(x, d, 1))
     return x
 end
+function Distributions._rand!(::Distributions.AbstractRNG, C::Copula{d}, ::AbstractMatrix{T}) where {d,T<:Real}
+    throw(ArgumentError("$(typeof(C)) must implement a matrix Distributions._rand! method"))
+end
 function Distributions.cdf(C::Copula{d},u::VT) where {d,VT<:AbstractVector}
     length(u) != d && throw(ArgumentError("Dimension mismatch between copula and input vector"))
     if any(iszero,u)

--- a/src/EllipticalCopula.jl
+++ b/src/EllipticalCopula.jl
@@ -48,15 +48,7 @@ References:
 """
 abstract type EllipticalCopula{d,MT} <: Copula{d} end
 Base.eltype(C::CT) where CT<:EllipticalCopula = Base.eltype(N(CT)(C.Σ))
-function Distributions._rand!(rng::Distributions.AbstractRNG, C::CT, x::AbstractVector{T}) where {T<:Real, CT <: EllipticalCopula}
-    Random.rand!(rng,N(CT)(C.Σ),x)
-    U₁ = U(CT)
-    @inbounds for i in eachindex(x)
-        x[i] = clamp(T(Distributions.cdf(U₁, x[i])), zero(T), one(T))
-    end
-    return x
-end
-function Distributions._rand!(rng::Distributions.AbstractRNG, C::CT, A::DenseMatrix{T}) where {T<:Real, CT<:EllipticalCopula}
+function Distributions._rand!(rng::Distributions.AbstractRNG, C::CT, A::AbstractMatrix{T}) where {T<:Real, CT<:EllipticalCopula}
     # More efficient version that precomputes stuff:
     n = N(CT)(C.Σ)
     u = U(CT)

--- a/src/ExtremeValueCopula.jl
+++ b/src/ExtremeValueCopula.jl
@@ -71,7 +71,7 @@ function τ⁻¹(::Type{T},τ_val) where {T<:ExtremeValueCopula{2}}
     return τ⁻¹(tailof(T),τ_val)
 end
 
-function Distributions._rand!(rng::Distributions.AbstractRNG, C::ExtremeValueCopula{2, TT}, X::DenseMatrix{T}) where {T<:Real, TT}
+function Distributions._rand!(rng::Distributions.AbstractRNG, C::ExtremeValueCopula{2, TT}, X::AbstractMatrix{T}) where {T<:Real, TT}
     # More efficient Matrix sampler:
     d,n = size(X)
     @assert d==2
@@ -84,16 +84,6 @@ function Distributions._rand!(rng::Distributions.AbstractRNG, C::ExtremeValueCop
         X[2,i] = exp(log(w)*(1-z)/a)
     end
     return X
-end
-function Distributions._rand!(rng::Distributions.AbstractRNG, C::ExtremeValueCopula{2, TT},
-                              x::AbstractVector{T}) where {T<:Real, TT}
-    u1, u2 = rand(rng), rand(rng)
-    z  = rand(rng, ExtremeDist(C.tail))
-    w  = (rand(rng) < _probability_z(C.tail, z)) ? u1 : (u1*u2)
-    a  = A(C.tail, z)
-    x[1] = exp(log(w)*z/a)
-    x[2] = exp(log(w)*(1-z)/a)
-    return x
 end
 DistortionFromCop(C::ExtremeValueCopula{2, TT}, js::NTuple{1,Int}, uⱼₛ::NTuple{1,Float64}, ::Int) where TT = BivEVDistortion(C.tail, Int8(js[1]), float(uⱼₛ[1]))
 

--- a/src/ExtremeValueCopula.jl
+++ b/src/ExtremeValueCopula.jl
@@ -151,11 +151,18 @@ function _fit(CT::Type{<:ExtremeValueCopula{d, GT} where {d, GT<:UnivariateTail2
         initial_params = start ∈ (:itau, :irho, :ibeta, :iupper) ? _fit(CT, U, Val{start}())[2].θ̂ : only(Distributions.params(_example(CT, d)))
         initial_params.θ
     end
-    # Keep the starting value away from open or infinite boundaries before
-    # mapping it to the tail's unconstrained parameterization.
-    θ0_clamped = clamp(θ0_val, iszero(lo) ? 1e-16 : lo, isinf(hi) ? 1e16 : hi)
+    # Keep the starting value strictly inside every finite boundary before
+    # mapping it to the tail's unconstrained parameterization. In particular,
+    # log and logit maps send otherwise valid boundary values to ±Inf.
+    Tθ = promote_type(typeof(float(θ0_val)), typeof(float(lo)), typeof(float(hi)))
+    loT, hiT = Tθ(lo), Tθ(hi)
+    inward(x) = sqrt(eps(Tθ)) * max(one(Tθ), abs(x))
+    lo_start = isfinite(loT) ? loT + inward(loT) : -Tθ(1e16)
+    hi_start = isfinite(hiT) ? hiT - inward(hiT) : Tθ(1e16)
+    θ0_clamped = clamp(Tθ(θ0_val), lo_start, hi_start)
     θ0 = (; θ=θ0_clamped)
     α0 = _unbound_params(CT, d, θ0)
+    all(isfinite, α0) || throw(ArgumentError("MLE start must map to finite unbounded parameters"))
     cop(α) = CT(d, _rebound_params(CT, d, α)...)
     f(α) = -Distributions.loglikelihood(cop(α), U)
     res = try

--- a/src/ExtremeValueCopula.jl
+++ b/src/ExtremeValueCopula.jl
@@ -151,14 +151,20 @@ function _fit(CT::Type{<:ExtremeValueCopula{d, GT} where {d, GT<:UnivariateTail2
         initial_params = start ∈ (:itau, :irho, :ibeta, :iupper) ? _fit(CT, U, Val{start}())[2].θ̂ : only(Distributions.params(_example(CT, d)))
         initial_params.θ
     end
-    # unbounded limits are bound to 1e16 (inf) and zero is bound to (1e-16) for stability
-    # the original bounds are still used for the optimization
+    # Keep the starting value away from open or infinite boundaries before
+    # mapping it to the tail's unconstrained parameterization.
     θ0_clamped = clamp(θ0_val, iszero(lo) ? 1e-16 : lo, isinf(hi) ? 1e16 : hi)
-    f(θ) = -Distributions.loglikelihood(CT(d, θ[1]), U)
-    res = Optim.optimize(f, Optim.TwiceDifferentiableConstraints([lo], [hi]), [θ0_clamped], Optim.IPNewton(), autodiff = ADTypes.AutoForwardDiff())
-    θ̂ = Optim.minimizer(res)[1]
-    θ̂ = Optim.minimizer(res)[1]
-    return CT(d, θ̂), (; θ̂=(;θ=θ̂), optimizer=:IPNewton,
+    θ0 = (; θ=θ0_clamped)
+    α0 = _unbound_params(CT, d, θ0)
+    cop(α) = CT(d, _rebound_params(CT, d, α)...)
+    f(α) = -Distributions.loglikelihood(cop(α), U)
+    res = try
+        Optim.optimize(f, α0, Optim.LBFGS(); autodiff=ADTypes.AutoForwardDiff())
+    catch
+        Optim.optimize(f, α0, Optim.NelderMead())
+    end
+    θ̂ = _rebound_params(CT, d, Optim.minimizer(res))
+    return CT(d, θ̂...), (; θ̂=θ̂, optimizer=Optim.summary(res),
                         xtol=xtol, converged=Optim.converged(res),
                         iterations=Optim.iterations(res))
 end

--- a/src/Generator/ClaytonGenerator.jl
+++ b/src/Generator/ClaytonGenerator.jl
@@ -112,15 +112,21 @@ function ρ⁻¹(::Type{<:ClaytonGenerator}, ρ̂; atol=1e-10)
     if isapprox(_ρ, 0.0; atol=1e-14)
         return 0.0
     end
-
-    # Seeds: we approximate τ ≈ (2/3)ρ and θ ≈ 2τ/(1-τ)
-    τ0 = clamp((2/3)*_ρ, -0.99, 0.99)
-    θ0 = 2*τ0/(1 - τ0)
-    θ0 = clamp(θ0, -1 + sqrt(eps(Float64)), 1e6)
-    θ1 = θ0 + (_ρ > 0 ? 0.25 : -0.25)        # second seed towards the right side
+    _ρ >= 1 && return Inf
+    _ρ <= -1 && return -1.0
 
     f(θ) = ρ(ClaytonGenerator(θ)) - _ρ
-    # Two-seeded blotter; no bracketing required
-    θ = Roots.find_zero(f, (θ0, θ1), Roots.Order2(); xatol=atol)
-    return θ
+    if _ρ < 0
+        bracket = (-1 + sqrt(eps(Float64)), 0.0)
+    else
+        # Spearman's rho increases to one with θ. Grow the upper endpoint
+        # until it brackets the requested value instead of relying on a
+        # secant step, which is fragile for strongly dependent samples.
+        upper = 1.0
+        while f(upper) < 0
+            upper *= 2
+        end
+        bracket = (0.0, upper)
+    end
+    return Roots.find_zero(f, bracket, Roots.Brent(); xatol=atol, rtol=0)
 end

--- a/src/Generator/ClaytonGenerator.jl
+++ b/src/Generator/ClaytonGenerator.jl
@@ -88,10 +88,6 @@ end
 𝒲₋₁(G::ClaytonGenerator, d::Int) = G.θ >= 0 ? WilliamsonFromFrailty(Distributions.Gamma(1/G.θ,G.θ), d) : ClaytonWilliamsonDistribution(G.θ,d)
 
 frailty(G::ClaytonGenerator) = G.θ >= 0 ? Distributions.Gamma(1/G.θ, G.θ) : throw(ArgumentError("Clayton frailty is only defined for θ ≥ 0 (positive dependence). Got θ = $(G.θ)."))
-function Distributions._rand!(rng::Distributions.AbstractRNG, C::ClaytonCopula, A::DenseMatrix{<:Real})
-    A[:] = inverse_rosenblatt(C, rand(rng, size(A)...))
-    return A
-end
 function Distributions._logpdf(C::ClaytonCopula{d,TG}, u) where {d,TG<:ClaytonGenerator}
     # Check if all elements are in (0,1) and if θ < 0, check the sum condition
     if !all(0 .< u .< 1) || (C.G.θ < 0 && sum(u .^ -(C.G.θ)) < (d - 1))

--- a/src/MiscellaneousCopulas/BernsteinCopula.jl
+++ b/src/MiscellaneousCopulas/BernsteinCopula.jl
@@ -131,26 +131,19 @@ function Distributions._logpdf(B::BernsteinCopula{d}, u::AbstractVector) where {
     return min(log(dens), zero(dens))
 end
 
-function Distributions._rand!(rng::Distributions.AbstractRNG, B::BernsteinCopula{d}, u::AbstractVector{T}) where {d,T<:Real}
+function Distributions._rand!(rng::Distributions.AbstractRNG, B::BernsteinCopula{d}, A::AbstractMatrix{T}) where {d,T<:Real}
+    size(A, 1) == d || throw(ArgumentError("Dimension mismatch between copula and output matrix"))
     m = B.m
-    target = rand(rng)
-    cum = 0.0
-    picked = nothing
-    weights = B.weights
-    @inbounds for s in Iterators.product((0:(mi-1) for mi in m)...)
-        w = weights[(s[j]+1 for j in 1:d)...]
-        w <= 0 && continue
-        cum += w
-        if cum >= target
-            picked = s
-            break
+    weights = max.(vec(B.weights), 0.0)
+    components = rand(rng, Distributions.Categorical(weights ./ sum(weights)), size(A, 2))
+    indices = CartesianIndices(B.weights)
+    @inbounds for (j, col) in enumerate(axes(A, 2))
+        s = Tuple(indices[components[j]])
+        for row in axes(A, 1)
+            A[row, col] = rand(rng, Distributions.Beta(s[row], m[row] + 1 - s[row]))
         end
     end
-    s = picked === nothing ? ntuple(j -> m[j]-1, d) : picked
-    @inbounds for j in 1:d
-        u[j] = Distributions.rand(rng, Distributions.Beta(s[j] + 1, m[j] - s[j]))
-    end
-    return u
+    return A
 end
 
 function DistortionFromCop(B::BernsteinCopula{D}, js::NTuple{p,Int}, uⱼₛ::NTuple{p,Float64}, i::Int) where {D,p}

--- a/src/MiscellaneousCopulas/BetaCopula.jl
+++ b/src/MiscellaneousCopulas/BetaCopula.jl
@@ -87,13 +87,14 @@ function Distributions._logpdf(C::BetaCopula{d}, u::AbstractVector) where {d}
     dens = max(dens, zero(dens))
     return log(dens + eps(eltype(dens)))
 end
-function Distributions._rand!(rng::Distributions.AbstractRNG, C::BetaCopula{d}, u::AbstractVector{T}) where {d,T<:Real}
-    i = Distributions.rand(rng, 1:C.n)  # choose a mixture component
-    @inbounds for j in 1:d
-        r = C.ranks[j,i]
-        u[j] = Distributions.rand(rng, Distributions.Beta(r, C.n + 1 - r))
+function Distributions._rand!(rng::Distributions.AbstractRNG, C::BetaCopula{d}, A::AbstractMatrix{T}) where {d,T<:Real}
+    size(A, 1) == d || throw(ArgumentError("Dimension mismatch between copula and output matrix"))
+    components = rand(rng, 1:C.n, size(A, 2))
+    @inbounds for (j, col) in enumerate(axes(A, 2)), row in axes(A, 1)
+        r = C.ranks[row, components[j]]
+        A[row, col] = rand(rng, Distributions.Beta(r, C.n + 1 - r))
     end
-    return u
+    return A
 end
 @inline function DistortionFromCop(C::BetaCopula{D,MT}, js::NTuple{p,Int}, uⱼₛ::NTuple{p,Float64}, i::Int) where {D,MT,p}
     # Build conditional mixture weights over observations given U_js = u_js.

--- a/src/MiscellaneousCopulas/CheckerboardCopula.jl
+++ b/src/MiscellaneousCopulas/CheckerboardCopula.jl
@@ -74,30 +74,16 @@ function _cdf(C::CheckerboardCopula{d}, u) where {d}
     return sum(w * prod(clamp.(um .- box, 0, 1)) for (box, w) in C.boxes)
 end
 
-function Distributions._rand!(rng::Distributions.AbstractRNG, C::CheckerboardCopula{d}, u::AbstractVector{T}) where {d,T<:Real}
-    # Draw a box index according to weights
-    r = rand(rng)
-    acc = 0.0
-    chosen = nothing
-    @inbounds for (box, w) in C.boxes
-        acc += w
-        if r <= acc
-            chosen = box
-            break
-        end
+function Distributions._rand!(rng::Distributions.AbstractRNG, C::CheckerboardCopula{d}, A::AbstractMatrix{T}) where {d,T<:Real}
+    size(A, 1) == d || throw(ArgumentError("Dimension mismatch between copula and output matrix"))
+    boxes = collect(keys(C.boxes))
+    weights = collect(values(C.boxes))
+    components = rand(rng, Distributions.Categorical(weights ./ sum(weights)), size(A, 2))
+    Random.rand!(rng, A)
+    @inbounds for (j, col) in enumerate(axes(A, 2)), row in axes(A, 1)
+        A[row, col] = T((boxes[components[j]][row] + A[row, col]) / C.m[row])
     end
-    # Fallback in case of tiny numerical drift (select the last box)
-    if chosen === nothing
-        for (box, _) in C.boxes
-            chosen = box
-        end
-    end
-    # Sample uniformly inside the chosen box
-    @inbounds for i in 1:d
-        bi = chosen[i]  # works for Tuple or Vector keys
-        u[i] = T((bi + rand(rng)) / C.m[i])
-    end
-    return u
+    return A
 end
 
 @inline function DistortionFromCop(C::CheckerboardCopula{D,T}, js::NTuple{p,Int}, uⱼₛ::NTuple{p,Float64}, i::Int) where {D, p, T}

--- a/src/MiscellaneousCopulas/EmpiricalCopula.jl
+++ b/src/MiscellaneousCopulas/EmpiricalCopula.jl
@@ -46,8 +46,13 @@ end
 function Distributions._logpdf(C::EmpiricalCopula{d,MT}, u) where {d,MT}
     any(C.u .== u) ? -log(size(C.u,2)) : -Inf
 end
-function Distributions._rand!(rng::Distributions.AbstractRNG, C::EmpiricalCopula{d,MT}, x::AbstractVector{T}) where {d,MT,T<:Real}
-    x .= C.u[:,Distributions.rand(rng,axes(C.u,2),1)[1]]
+function Distributions._rand!(rng::Distributions.AbstractRNG, C::EmpiricalCopula{d,MT}, A::AbstractMatrix{T}) where {d,MT,T<:Real}
+    size(A, 1) == d || throw(ArgumentError("Dimension mismatch between copula and output matrix"))
+    indices = rand(rng, axes(C.u, 2), size(A, 2))
+    @inbounds for (j, col) in enumerate(axes(A, 2)), row in axes(A, 1)
+        A[row, col] = C.u[row, indices[j]]
+    end
+    return A
 end
 StatsBase.corkendall(C::EmpiricalCopula) = StatsBase.corkendall(C.u')
 

--- a/src/MiscellaneousCopulas/FGMCopula.jl
+++ b/src/MiscellaneousCopulas/FGMCopula.jl
@@ -93,12 +93,16 @@ end
 
 _cdf(fgm::FGMCopula, u::Vector{T}) where {T} = prod(u) * (1 + _fgm_red(fgm.θ, 1 .-u))
 Distributions._logpdf(fgm::FGMCopula, u) = log1p(_fgm_red(fgm.θ, 1 .-2u))
-function Distributions._rand!(rng::Distributions.AbstractRNG, fgm::FGMCopula{d, Tθ, Tf}, x::AbstractVector{T}) where {d,Tθ, Tf, T <: Real}
-    I = Base.reverse(digits(rand(rng,fgm.fᵢ), base=2, pad=d))
-    V₀ = rand(rng, d)
-    V₁ = rand(rng, d)
-    x .= 1 .- sqrt.(V₀) .* (V₁ .^ I)
-    return x
+function Distributions._rand!(rng::Distributions.AbstractRNG, fgm::FGMCopula{d, Tθ, Tf}, A::AbstractMatrix{T}) where {d,Tθ, Tf, T <: Real}
+    size(A, 1) == d || throw(ArgumentError("Dimension mismatch between copula and output matrix"))
+    Random.rand!(rng, A)
+    V₁ = rand(rng, T, size(A))
+    states = rand(rng, fgm.fᵢ, size(A, 2))
+    @inbounds for (j, col) in enumerate(axes(A, 2)), (i, row) in enumerate(axes(A, 1))
+        bit = (states[j] >> (d - i)) & 1
+        A[row, col] = one(T) - sqrt(A[row, col]) * (iszero(bit) ? one(T) : V₁[i, j])
+    end
+    return A
 end
 τ(fgm::FGMCopula{2, Tθ, Tf}) where {Tθ,Tf} = (2*fgm.θ[1])/9
 function τ⁻¹(::Type{<:FGMCopula}, τ)

--- a/src/MiscellaneousCopulas/IndependentCopula.jl
+++ b/src/MiscellaneousCopulas/IndependentCopula.jl
@@ -18,10 +18,8 @@ end
 _cdf(::IndependentCopula{d}, u) where d = prod(u)
 Distributions._logpdf(::IndependentCopula{d}, u) where {d} = all(0 .<= u .<= 1) ? zero(eltype(u)) : eltype(u)(-Inf)
 
-function Distributions._rand!(rng::Distributions.AbstractRNG, ::IndependentCopula{d}, x::AbstractVector{T}) where {d,T<:Real}
-    Random.rand!(rng,x)
-end
-function Distributions._rand!(rng::Distributions.AbstractRNG, ::IndependentCopula{d}, A::DenseMatrix{T}) where {T<:Real, d}
+function Distributions._rand!(rng::Distributions.AbstractRNG, ::IndependentCopula{d}, A::AbstractMatrix{T}) where {T<:Real, d}
+    size(A, 1) == d || throw(ArgumentError("Dimension mismatch between copula and output matrix"))
     Random.rand!(rng,A)
     return A
 end

--- a/src/MiscellaneousCopulas/MCopula.jl
+++ b/src/MiscellaneousCopulas/MCopula.jl
@@ -18,8 +18,13 @@ end
 Distributions._logpdf(::MCopula{d}, u) where {d} = all(u == u[1]) ? zero(eltype(u)) : eltype(u)(-Inf)
 _cdf(::MCopula{d}, u) where {d} = Base.minimum(u)
 
-function Distributions._rand!(rng::Distributions.AbstractRNG, ::MCopula{d}, x::AbstractVector{T}) where {d,T<:Real}
-    x .= rand(rng)
+function Distributions._rand!(rng::Distributions.AbstractRNG, ::MCopula{d}, A::AbstractMatrix{T}) where {d,T<:Real}
+    size(A, 1) == d || throw(ArgumentError("Dimension mismatch between copula and output matrix"))
+    Random.rand!(rng, view(A, 1, :))
+    @inbounds for row in 2:d
+        A[row, :] .= view(A, 1, :)
+    end
+    return A
 end
 τ(::MCopula) = 1
 ρ(::MCopula) = 1

--- a/src/MiscellaneousCopulas/PlackettCopula.jl
+++ b/src/MiscellaneousCopulas/PlackettCopula.jl
@@ -72,17 +72,19 @@ function Distributions._logpdf(S::PlackettCopula{P}, uv) where {P}
 end
 import Random
 
-function Distributions._rand!(rng::Distributions.AbstractRNG, C::CT, x::AbstractVector{T}) where {T<:Real, CT<:PlackettCopula}
-    u = rand(rng)
-    t = rand(rng)
-    a = t * (1 - t)
-    b = C.θ + a * (C.θ - 1)^2
-    cc = 2a * (u * C.θ^2 + 1 - u) + C.θ * (1 - 2a)
-    d = sqrt(C.θ) * sqrt(C.θ + 4a * u * (1 - u) * (1 - C.θ)^2)
-    v = (cc - (1 - 2t) * d) / (2b)
-    x[1] = u
-    x[2] = v
-    return x
+function Distributions._rand!(rng::Distributions.AbstractRNG, C::CT, A::AbstractMatrix{T}) where {T<:Real, CT<:PlackettCopula}
+    size(A, 1) == 2 || throw(ArgumentError("Dimension mismatch between copula and output matrix"))
+    Random.rand!(rng, view(A, 1, :))
+    ts = rand(rng, T, size(A, 2))
+    @inbounds for (j, col) in enumerate(axes(A, 2))
+        u, t = A[1, col], ts[j]
+        a = t * (one(T) - t)
+        b = C.θ + a * (C.θ - 1)^2
+        cc = 2a * (u * C.θ^2 + 1 - u) + C.θ * (1 - 2a)
+        root = sqrt(C.θ) * sqrt(C.θ + 4a * u * (1 - u) * (1 - C.θ)^2)
+        A[2, col] = (cc - (1 - 2t) * root) / (2b)
+    end
+    return A
 end
 
 # Calculate Spearman's rho based on the PlackettCopula parameters

--- a/src/MiscellaneousCopulas/RafteryCopula.jl
+++ b/src/MiscellaneousCopulas/RafteryCopula.jl
@@ -68,19 +68,18 @@ function Distributions._logpdf(R::RafteryCopula{d,P}, u) where {d,P}
     l_prd = (R.θ) / (1 - R.θ) * log(prod(u))
     return l_num - l_den + l_prd
 end
-function Distributions._rand!(rng::Distributions.AbstractRNG, R::RafteryCopula{d,P}, x::AbstractVector{T}) where {d,P,T <: Real}
-    # Step 1: Generate independent values u, u_1, ..., u_d from a uniform distribution [0, 1]
-    u = rand(rng, d)
-
-    # Step 2: Generate j from a Bernoulli distribution with parameter θ
-    uj = (rand(rng)<R.θ) ? rand(rng) : 1
-
-    # Step 3: Calculate v_1, ..., v_d
-    for i in 1:d
-        x[i] = u[i]^(1 - R.θ) * uj
+function Distributions._rand!(rng::Distributions.AbstractRNG, R::RafteryCopula{d,P}, A::AbstractMatrix{T}) where {d,P,T <: Real}
+    size(A, 1) == d || throw(ArgumentError("Dimension mismatch between copula and output matrix"))
+    Random.rand!(rng, A)
+    common = rand(rng, T, size(A, 2))
+    selectors = rand(rng, T, size(A, 2))
+    @inbounds for (j, col) in enumerate(axes(A, 2))
+        uj = selectors[j] < R.θ ? common[j] : one(T)
+        for row in axes(A, 1)
+            A[row, col] = A[row, col]^(one(T) - R.θ) * uj
+        end
     end
-    
-    return x
+    return A
 end
 function ρ(R::RafteryCopula{d,P}) where {d, P}
     term1 = (d+1)*(2^d-(2-R.θ)^d)-(2^d*R.θ*d)
@@ -100,4 +99,3 @@ function τ(R::RafteryCopula{d, P}) where {d, P}
     
     return term1 + term2 - term3 - term4
 end
-

--- a/src/MiscellaneousCopulas/SurvivalCopula.jl
+++ b/src/MiscellaneousCopulas/SurvivalCopula.jl
@@ -68,9 +68,10 @@ function _cdf(C::SurvivalCopula{d,CT,flips}, u) where {d,CT,flips}
     return r1 - r2
 end
 Distributions._logpdf(C::SurvivalCopula{d,CT,flips}, u) where {d,CT,flips} = Distributions._logpdf(C.C, reverse(u, flips))
-function Distributions._rand!(rng::Distributions.AbstractRNG, C::SurvivalCopula{d,CT,flips}, x::AbstractVector{T}) where {d,CT,flips,T<:Real}
-    Distributions._rand!(rng, C.C, x)
-    reverse!(x, flips)
+function Distributions._rand!(rng::Distributions.AbstractRNG, C::SurvivalCopula{d,CT,flips}, A::AbstractMatrix{T}) where {d,CT,flips,T<:Real}
+    size(A, 1) == d || throw(ArgumentError("Dimension mismatch between copula and output matrix"))
+    Distributions._rand!(rng, C.C, A)
+    return reverse!(A, flips)
 end
 
 # Fitting: delegate to the base copula after flipping the requested indices in U

--- a/src/MiscellaneousCopulas/WCopula.jl
+++ b/src/MiscellaneousCopulas/WCopula.jl
@@ -19,11 +19,13 @@ end
 Distributions._logpdf(::WCopula,           u) = sum(u) == 1 ? zero(eltype(u)) : eltype(u)(-Inf)
 _cdf(::WCopula, u) = max(sum(u)-1,0)
 
-function Distributions._rand!(rng::Distributions.AbstractRNG, ::WCopula, x::AbstractVector{T}) where {T<:Real}
-    @assert length(x)==2
-    x[1] = rand(rng)
-    x[2] = 1-x[1]
-    return x
+function Distributions._rand!(rng::Distributions.AbstractRNG, ::WCopula, A::AbstractMatrix{T}) where {T<:Real}
+    size(A, 1) == 2 || throw(ArgumentError("Dimension mismatch between copula and output matrix"))
+    Random.rand!(rng, view(A, 1, :))
+    @inbounds for col in axes(A, 2)
+        A[2, col] = one(T) - A[1, col]
+    end
+    return A
 end
 τ(::WCopula) = -1
 ρ(::WCopula) = -1

--- a/src/NestedArchimedeanCopula.jl
+++ b/src/NestedArchimedeanCopula.jl
@@ -592,16 +592,18 @@ end
 # Sampling. NestedArchimedeanCopula has no bespoke Marshall–Olkin frailty
 # sampler; instead we draw via the inverse Rosenblatt transform, which is driven
 # by our closed-form `_cdf`/`DistortionFromCop`/`subsetdims` specialisations
-# (nested/NestedConditioning.jl). A single VECTOR `_rand!` is enough — the
-# Distributions.jl `rand(C, n)` matrix path loops over this vector form (mirrors
-# ArchimedeanCopula/SubsetCopula). Dispatches only on NestedArchimedeanCopula, so
-# the flat-collapse ArchimedeanCopula sampler is untouched. The per-coordinate
-# inverse-CDF is an O(d) sequential bisection (≈ms/sample); keep sampled N modest.
+# (nested/NestedConditioning.jl). The matrix sampler applies the inverse
+# Rosenblatt transform to a complete batch; the generic copula vector sampler
+# delegates to this method with a single-column matrix. Dispatches only on
+# NestedArchimedeanCopula, so the flat-collapse ArchimedeanCopula sampler is
+# untouched. The per-coordinate inverse-CDF is an O(d) sequential bisection
+# (≈ms/sample); keep sampled N modest.
 function Distributions._rand!(rng::Distributions.AbstractRNG,
                               C::NestedArchimedeanCopula{d},
-                              x::AbstractVector{T}) where {T<:Real, d}
-    x .= inverse_rosenblatt(C, rand(rng, T, d))
-    return x
+                              A::AbstractMatrix{T}) where {T<:Real, d}
+    size(A, 1) == d || throw(ArgumentError("Dimension mismatch between copula and output matrix"))
+    A .= inverse_rosenblatt(C, rand(rng, T, size(A)))
+    return A
 end
 
 # Copula-scale mixed partial of the nested CDF over the observed coordinates.

--- a/src/SklarDist.jl
+++ b/src/SklarDist.jl
@@ -83,6 +83,10 @@ function Distributions._rand!(rng::Distributions.AbstractRNG, S::SklarDist{CT,Tp
     end
     return A
 end
+function Distributions._rand!(rng::Distributions.AbstractRNG, S::SklarDist, x::AbstractVector{T}) where {T<:Real}
+    Distributions._rand!(rng, S, reshape(x, length(S), 1))
+    return x
+end
 function Distributions._logpdf(S::SklarDist{CT,TplMargins}, u) where {CT,TplMargins}
     d = length(S)
     T = _sklar_work_eltype(S, u)

--- a/src/SklarDist.jl
+++ b/src/SklarDist.jl
@@ -74,10 +74,14 @@ function Distributions.cdf(S::SklarDist{CT,TplMargins}, x) where {CT,TplMargins}
     return Distributions.cdf(S.C, u)
 end
 Distributions.logcdf(S::SklarDist{CT,TplMargins},x) where {CT,TplMargins} = log(Distributions.cdf(S, x))
-function Distributions._rand!(rng::Distributions.AbstractRNG, S::SklarDist{CT,TplMargins}, x::AbstractVector{T}) where {CT,TplMargins,T}
-    Random.rand!(rng,S.C,x)
-    clamp!(x, nextfloat(T(0)), prevfloat(T(1)))
-    x .= Distributions.quantile.(S.m,x)
+function Distributions._rand!(rng::Distributions.AbstractRNG, S::SklarDist{CT,TplMargins}, A::AbstractMatrix{T}) where {CT,TplMargins,T}
+    size(A, 1) == length(S) || throw(ArgumentError("Dimension mismatch between distribution and output matrix"))
+    Random.rand!(rng, S.C, A)
+    lo, hi = nextfloat(T(0)), prevfloat(T(1))
+    @inbounds for col in axes(A, 2), row in axes(A, 1)
+        A[row, col] = Distributions.quantile(S.m[row], clamp(A[row, col], lo, hi))
+    end
+    return A
 end
 function Distributions._logpdf(S::SklarDist{CT,TplMargins}, u) where {CT,TplMargins}
     d = length(S)

--- a/src/Subsetting.jl
+++ b/src/Subsetting.jl
@@ -35,10 +35,13 @@ function SubsetCopula(CS::SubsetCopula{d,CT}, dims2::NTuple{p, Int}) where {d,CT
 end
 _available_fitting_methods(::Type{<:SubsetCopula}, d) = Tuple{}() # cannot be fitted. 
 Base.eltype(C::SubsetCopula{d,CT}) where {d,CT} = Base.eltype(C.C)
-function Distributions._rand!(rng::Distributions.AbstractRNG, C::SubsetCopula{d,CT}, x::AbstractVector{T}) where {T<:Real, d,CT}
-    u = Random.rand(rng,C.C)
-    x .= (u[i] for i in C.dims)
-    return x
+function Distributions._rand!(rng::Distributions.AbstractRNG, C::SubsetCopula{d,CT}, A::AbstractMatrix{T}) where {T<:Real, d,CT}
+    size(A, 1) == d || throw(ArgumentError("Dimension mismatch between copula and output matrix"))
+    U = rand(rng, C.C, size(A, 2))
+    @inbounds for (row, source) in enumerate(C.dims), col in axes(A, 2)
+        A[row, col] = U[source, col]
+    end
+    return A
 end
 function _cdf(C::SubsetCopula{d,CT},u) where {d,CT}
     # Simplyu saturate dimensions that are not choosen.

--- a/src/Tail/BC2Tail.jl
+++ b/src/Tail/BC2Tail.jl
@@ -53,12 +53,16 @@ function ρ(C::ExtremeValueCopula{2, BC2Tail{T}}) where {T}
     den = (3 - a - b - min(a,b)) * (a + b + max(a,b))
     return num / den
 end
-function Distributions._rand!(rng::Distributions.AbstractRNG, C::ExtremeValueCopula{2, BC2Tail{T}}, u::AbstractVector{S}) where {T,S<:Real}
+function Distributions._rand!(rng::Distributions.AbstractRNG, C::ExtremeValueCopula{2, BC2Tail{T}}, A::AbstractMatrix{S}) where {T,S<:Real}
+    size(A, 1) == 2 || throw(ArgumentError("Dimension mismatch between copula and output matrix"))
     a, b = C.tail.a, C.tail.b
-    v1, v2 = rand(rng, Distributions.Uniform(0,1), 2)
-    u[1] = max(v1^(1/a), v2^(1/(1-a)))
-    u[2] = max(v1^(1/b), v2^(1/(1-b)))
-    return u
+    V = rand(rng, S, 2, size(A, 2))
+    @inbounds for (j, col) in enumerate(axes(A, 2))
+        v1, v2 = V[1, j], V[2, j]
+        A[1, col] = max(v1^(1/a), v2^(1/(1-a)))
+        A[2, col] = max(v1^(1/b), v2^(1/(1-b)))
+    end
+    return A
 end
 function Distributions.logcdf(D::BivEVDistortion{<:BC2Tail{TF1}, TF2}, z::Real) where {TF1,TF2}
     T = promote_type(TF1, TF2, typeof(z))

--- a/src/Tail/CuadrasAugeTail.jl
+++ b/src/Tail/CuadrasAugeTail.jl
@@ -56,13 +56,16 @@ dA(C::ExtremeValueCopula{2, CuadrasAugeTail{T}}, t::Real) where {T} = (t <= 0.5 
 ℓ(C::ExtremeValueCopula{2, CuadrasAugeTail{T}}, t) where {T} = max(t[1], t[2]) + (1 - C.tail.θ) * min(t[1], t[2])
 function Distributions._rand!(rng::Distributions.AbstractRNG,
     C::ExtremeValueCopula{2, CuadrasAugeTail{T}},
-    x::AbstractVector{S}) where {T,S<:Real}
+    A::AbstractMatrix{S}) where {T,S<:Real}
+    size(A, 1) == 2 || throw(ArgumentError("Dimension mismatch between copula and output matrix"))
     θ = C.tail.θ
-    E₁, E₂ = rand(rng, Distributions.Exponential(θ/(1-θ)), 2)
-    E₁₂ = rand(rng, Distributions.Exponential())
-    x[1] = exp(-(1/θ) * min(E₁, E₁₂))
-    x[2] = exp(-(1/θ) * min(E₂, E₁₂))
-    return x
+    E = rand(rng, Distributions.Exponential(θ/(1-θ)), 2, size(A, 2))
+    E₁₂ = rand(rng, Distributions.Exponential(), size(A, 2))
+    @inbounds for (j, col) in enumerate(axes(A, 2))
+        A[1, col] = exp(-(1/θ) * min(E[1, j], E₁₂[j]))
+        A[2, col] = exp(-(1/θ) * min(E[2, j], E₁₂[j]))
+    end
+    return A
 end
 function Distributions.logcdf(D::BivEVDistortion{CuadrasAugeTail{T}, S}, z::Real) where {T,S}
     θ = D.tail.θ

--- a/src/Tail/MOTail.jl
+++ b/src/Tail/MOTail.jl
@@ -65,6 +65,30 @@ function τ(C::MOCopula)
     b = C.tail.λ₂/(C.tail.λ₂+C.tail.λ₁₂)
     return a*b/(a+b-a*b)
 end
+
+function Distributions._rand!(rng::Distributions.AbstractRNG, C::MOCopula,
+                              A::AbstractMatrix{S}) where {S<:Real}
+    size(A, 1) == 2 || throw(ArgumentError("Dimension mismatch between copula and output matrix"))
+    λ₁, λ₂, λ₁₂ = C.tail.λ₁, C.tail.λ₂, C.tail.λ₁₂
+    T = promote_type(typeof(float(λ₁)), typeof(float(λ₂)), typeof(float(λ₁₂)))
+    λ₁T, λ₂T, λ₁₂T = T(λ₁), T(λ₂), T(λ₁₂)
+    rate_u, rate_v = λ₂T + λ₁₂T, λ₁T + λ₁₂T
+    (rate_u > 0 && rate_v > 0) ||
+        throw(ArgumentError("Each Marshall-Olkin margin must have a positive total rate"))
+    waiting_time(rate) = iszero(rate) ? T(Inf) : T(Random.randexp(rng)) / rate
+
+    # The first Pickands coordinate used by A is -log(u), so its private
+    # shock has rate λ₂; the second coordinate analogously uses rate λ₁.
+    @inbounds for col in axes(A, 2)
+        private_u = waiting_time(λ₂T)
+        private_v = waiting_time(λ₁T)
+        common = waiting_time(λ₁₂T)
+        A[1, col] = exp(-rate_u * min(private_u, common))
+        A[2, col] = exp(-rate_v * min(private_v, common))
+    end
+    return A
+end
+
 function Distributions.logcdf(D::BivEVDistortion{MOTail{T}, S}, z::Real) where {T, S}
     a = D.tail.λ₁ / (D.tail.λ₁ + D.tail.λ₁₂)
     b = D.tail.λ₂ / (D.tail.λ₂ + D.tail.λ₁₂)

--- a/test/ArchimedeanCopulas.jl
+++ b/test/ArchimedeanCopulas.jl
@@ -91,6 +91,9 @@ end
     @test Copulas.ρ⁻¹(ClaytonCopula, 1/3) ≈ 0.58754 atol=1.0e-5
     @test Copulas.ρ⁻¹(ClaytonCopula, 0.01) ≈ 0. atol=1.0e-1
     @test Copulas.ρ⁻¹(ClaytonCopula, -0.4668) ≈ -.5 atol=1.0e-3
+    ρstrong = Copulas.ρ(ClaytonCopula(2, 7.3))
+    @test Copulas.ρ⁻¹(ClaytonCopula, ρstrong) ≈ 7.3 atol=1.0e-5
+    @test Copulas.ρ⁻¹(ClaytonCopula, 1.0) == Inf
 
     @test Copulas.ρ⁻¹(GumbelCopula, 0.5) ≈ 1.5410704204332681
     @test_broken Copulas.ρ⁻¹(GumbelCopula, 0.0001) == 1.

--- a/test/FittingTest.jl
+++ b/test/FittingTest.jl
@@ -92,6 +92,17 @@
     end
 end
 
+@testset "Extreme-value MLE accepts boundary starts" begin
+    U = [0.10 0.25 0.40 0.55 0.70 0.85;
+         0.15 0.20 0.45 0.60 0.75 0.90]
+
+    for CT in (CuadrasAugeCopula, LogCopula)
+        fitted = fit(CT, U, :mle; start=1.0)
+        @test fitted isa Copula
+        @test all(isfinite, Distributions.params(fitted))
+    end
+end
+
 @testset "Dependence Metrics" begin
     Random.seed!(rng,123)
     n_samples = 2000

--- a/test/FittingTest.jl
+++ b/test/FittingTest.jl
@@ -98,7 +98,7 @@ end
 
     for CT in (CuadrasAugeCopula, LogCopula)
         fitted = fit(CT, U, :mle; start=1.0)
-        @test fitted isa Copula
+        @test fitted isa Copulas.Copula
         @test all(isfinite, Distributions.params(fitted))
     end
 end

--- a/test/GenericTests.jl
+++ b/test/GenericTests.jl
@@ -533,8 +533,36 @@ Bestiary = filter(GenericTestFilter, Bestiary)
             @test abs(p_hat - p_th) ≤ max(5*se, 2e-3)
         end
 
+        @testif (C isa BC2Copula || C isa MOCopula || C isa CuadrasAugeCopula) "Singular sampler structure" begin
+            # The empirical-CDF check is fragile for these singular laws.
+            # Check their margins and analytically known singular mass instead.
+            @test all(isapprox.(vec(mean(spl1000; dims=2)), 0.5; atol=0.04, rtol=0))
 
-        # This test takes more than 5 hours to run 
+            x = .-log.(spl1000[1, :])
+            y = .-log.(spl1000[2, :])
+            if C isa BC2Copula
+                a, b = C.tail.a, C.tail.b
+                ray1 = isapprox.(a .* x, b .* y; atol=1e-10, rtol=1e-7)
+                ray2 = isapprox.((1-a) .* x, (1-b) .* y; atol=1e-10, rtol=1e-7)
+                observed = mean(ray1 .| ray2)
+                expected = 1 - abs(a-b)
+            elseif C isa MOCopula
+                λ₁, λ₂, λ₁₂ = C.tail.λ₁, C.tail.λ₂, C.tail.λ₁₂
+                atom = isapprox.((λ₂+λ₁₂) .* x, (λ₁+λ₁₂) .* y;
+                                atol=1e-10, rtol=1e-7)
+                observed = mean(atom)
+                expected = λ₁₂ / (λ₁ + λ₂ + λ₁₂)
+            else
+                θ = C.tail.θ
+                observed = mean(spl1000[1, :] .== spl1000[2, :])
+                expected = θ / (2-θ)
+            end
+            se = sqrt(expected * (1-expected) / size(spl1000, 2))
+            @test abs(observed-expected) <= max(5*se, 0.01)
+        end
+
+
+        # This test takes more than 5 hours to run
         # This is clarly unacceptable, but moreover we dont know which copula takes the most time 
         # sadly ;)
         

--- a/test/GenericTests.jl
+++ b/test/GenericTests.jl
@@ -449,11 +449,22 @@ function _integrate_pdf_rect(rng, C::Copulas.Copula{d}, a, b, N) where d
     return μ, r, :mc_pdf
 end
 
-# You can filter the bestiary here if you want: 
+# You can filter the bestiary here if you want:
 Bestiary = filter(GenericTestFilter, Bestiary)
 
-# Launch the main computation: 
-@testset for C in unique(Bestiary) 
+@testset "Matrix sampler accepts generic buffers" begin
+    C = ClaytonCopula(3, 1.0)
+    storage = fill(Float32(NaN), 5, 2)
+    A = @view storage[2:4, :]
+
+    @test rand!(StableRNG(260), C, A) === A
+    @test all(0f0 .<= A .<= 1f0)
+    @test all(isnan, storage[[1, 5], :])
+    @test_throws DimensionMismatch rand!(StableRNG(260), C, zeros(Float32, 2, 1))
+end
+
+# Launch the main computation:
+@testset for C in unique(Bestiary)
 
     @info "Testing $C..."
     Random.seed!(rng,123)

--- a/test/GenericTests.jl
+++ b/test/GenericTests.jl
@@ -466,14 +466,25 @@ Bestiary = filter(GenericTestFilter, Bestiary)
     spl1000 = rand(rng, C, 1000)
 
     @testset "Basics" begin 
-        @testset "Shape and support" begin 
+        @testset "Shape and support" begin
             @test length(spl1)==d
             @test size(spl10) == (d,10)
             @test all(0 .<= spl10 .<= 1)
             @test all(0 .<= spl1000 .<= 1)
         end
 
-        @testset "CDF boundary and measure" begin 
+        @testset "Matrix-first sampler dispatch" begin
+            vector_fallback = which(Distributions._rand!,
+                                    (typeof(rng), Copulas.Copula{d}, Vector{Float64}))
+            matrix_fallback = which(Distributions._rand!,
+                                    (typeof(rng), Copulas.Copula{d}, Matrix{Float64}))
+            @test which(Distributions._rand!,
+                        (typeof(rng), CT, Vector{Float64})) == vector_fallback
+            @test which(Distributions._rand!,
+                        (typeof(rng), CT, Matrix{Float64})) != matrix_fallback
+        end
+
+        @testset "CDF boundary and measure" begin
             @test iszero(cdf(C,zeros(d)))
             @test isone(cdf(C,ones(d)))
             @test 0 <= cdf(C,rand(rng,d)) <= 1

--- a/test/GenericTests.jl
+++ b/test/GenericTests.jl
@@ -559,7 +559,7 @@ end
                 expected = 1 - abs(a-b)
             elseif C isa MOCopula
                 λ₁, λ₂, λ₁₂ = C.tail.λ₁, C.tail.λ₂, C.tail.λ₁₂
-                atom = isapprox.((λ₂+λ₁₂) .* x, (λ₁+λ₁₂) .* y;
+                atom = isapprox.((λ₁+λ₁₂) .* x, (λ₂+λ₁₂) .* y;
                                 atol=1e-10, rtol=1e-7)
                 observed = mean(atom)
                 expected = λ₁₂ / (λ₁ + λ₂ + λ₁₂)

--- a/test/SklarDist.jl
+++ b/test/SklarDist.jl
@@ -12,7 +12,9 @@
         d = length(C)
         Z = Copulas.SklarDist(C, ntuple(_->Normal(), d))
         spl10 = rand(rng, C, 10)
+        splZ1 = rand(rng, Z)
         splZ10 = rand(rng, Z, 10)
+        @test length(splZ1) == d
 
         # subsetdims should work and agree through SklarDist wrapping
         @testset "subsetdims wiring (d=$(d), $(typeof(C)))" begin


### PR DESCRIPTION
## Summary

This PR migrates Copulas.jl to a matrix-first sampling contract:

- every copula family provides a matrix `_rand!` primitive;
- the generic vector sampler delegates through a `d × 1` reshape;
- vector specializations remain optional when they provide a measured performance benefit;
- wrappers and data-driven copulas delegate or batch their matrix sampling paths;
- Marshall–Olkin uses an exact shock-based matrix sampler that preserves its discrete singular mass;
- the developer documentation describes the matrix-first extension contract.

It also hardens two fitting paths exposed by the generic tests: strongly dependent Clayton Spearman inversion now uses a bracketed root, and one-parameter extreme-value MLE starts remain finite after transformation to unconstrained parameters.

## Tests

- generic dispatch and sampling checks across the copula bestiary;
- a small `Float32` non-dense matrix-buffer contract test;
- structural sampling checks for the singular BC2, Marshall–Olkin, and Cuadras–Augé families, reusing existing samples;
- focused regressions for Clayton Spearman inversion and extreme-value MLE boundary starts.

Closes #260

> This PR description and the implementation were prepared with assistance from an LLM and should be reviewed accordingly.