### PR TITLE
Add Tachometer performance benchmarks

### DIFF
--- a/.github/workflows/Benchmark.yml
+++ b/.github/workflows/Benchmark.yml
@@ -1,0 +1,37 @@
+# Untrusted half of Tachometer's fork-safe two-workflow setup. This workflow
+# executes pull-request code with a read-only token and only uploads results.
+name: Benchmarks
+
+on:
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'LICENSE'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: tachometer-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  benchmark:
+    name: Benchmark
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: KristofferC/Tachometer.jl@334a994520a7e1c80167a5db1289d4f8f5d9c8d3
+        with:
+          julia-version: "1"
+          nruns: "3"
+          time-tolerance: "5%"
+          memory-tolerance: "5%"
+          time-floor: "1us"
+          fail-on-regression: "true"

--- a/.github/workflows/BenchmarkReport.yml
+++ b/.github/workflows/BenchmarkReport.yml
@@ -1,0 +1,23 @@
+# Trusted half of Tachometer's fork-safe two-workflow setup. It never executes
+# pull-request code; it validates uploaded results and maintains the PR comment.
+name: Benchmark report
+
+on:
+  workflow_run:
+    workflows: [Benchmarks]
+    types: [requested, completed]
+
+permissions:
+  pull-requests: write
+  actions: read
+  contents: read
+
+jobs:
+  report:
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    concurrency:
+      group: tachometer-report-${{ github.event.action }}-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
+      cancel-in-progress: ${{ github.event.action == 'requested' }}
+    steps:
+      - uses: KristofferC/Tachometer.jl/reporter@334a994520a7e1c80167a5db1289d4f8f5d9c8d3

--- a/.github/workflows/BenchmarkTrack.yml
+++ b/.github/workflows/BenchmarkTrack.yml
@@ -1,0 +1,137 @@
+# Track default-branch performance and publish the static Tachometer dashboard
+# below benchmarks/ on the gh-pages branch shared with the documentation.
+name: Benchmark tracking
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  record:
+    name: Record
+    if: github.ref_type != 'tag'
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 45
+    concurrency:
+      group: tachometer-record-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      benchmarked: ${{ steps.scope.outputs.code-changed }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for code changes
+        id: scope
+        env:
+          BEFORE: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+          if [ -z "${BEFORE:-}" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ] \
+             || ! git cat-file -e "${BEFORE}^{commit}" 2>/dev/null; then
+            echo "no usable base commit (new branch, manual run, or force-push); benchmarking"
+            echo "code-changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          changed="$(git diff --name-only "$BEFORE" "$GITHUB_SHA" -- . \
+            ':(exclude,glob)**/*.md' ':(exclude,glob)docs/**' ':(exclude)LICENSE')"
+          if [ -n "$changed" ]; then
+            echo "code-changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "docs-only push; skipping benchmark"
+            echo "code-changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: julia-actions/setup-julia@v2
+        if: steps.scope.outputs.code-changed == 'true'
+        with:
+          version: "1"
+      - uses: julia-actions/cache@v2
+        if: steps.scope.outputs.code-changed == 'true'
+
+      - name: Install Tachometer
+        if: steps.scope.outputs.code-changed == 'true'
+        run: |
+          julia --project=.tacho -e '
+            using Pkg
+            Pkg.add(
+              url = "https://github.com/KristofferC/Tachometer.jl",
+              rev = "334a994520a7e1c80167a5db1289d4f8f5d9c8d3",
+            )
+            Pkg.instantiate()'
+
+      - name: Record
+        if: steps.scope.outputs.code-changed == 'true'
+        env:
+          TACHOMETER_MODE: record
+          TACHOMETER_SCRIPT: benchmark/benchmarks.jl
+          TACHOMETER_RECORD_OUT: ${{ github.workspace }}/tachometer-record.json
+        run: julia --project=.tacho --startup-file=no -e 'using Tachometer; Tachometer.main()'
+
+      - uses: actions/upload-artifact@v4
+        if: steps.scope.outputs.code-changed == 'true'
+        with:
+          name: tachometer-record
+          path: ${{ github.workspace }}/tachometer-record.json
+          retention-days: 7
+
+  publish:
+    name: Publish to Pages
+    needs: [record]
+    if: >-
+      always() && (
+        github.ref_type == 'tag' ||
+        (needs.record.result == 'success' && needs.record.outputs.benchmarked == 'true')
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: write
+    concurrency:
+      group: gh-pages-publish
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: "1"
+      - uses: julia-actions/cache@v2
+
+      - name: Install Tachometer
+        run: |
+          julia --project=.tacho -e '
+            using Pkg
+            Pkg.add(
+              url = "https://github.com/KristofferC/Tachometer.jl",
+              rev = "334a994520a7e1c80167a5db1289d4f8f5d9c8d3",
+            )
+            Pkg.instantiate()'
+
+      - name: Download record
+        if: github.ref_type != 'tag'
+        uses: actions/download-artifact@v4
+        with:
+          name: tachometer-record
+          path: ${{ runner.temp }}/record
+
+      - name: Publish to Pages
+        env:
+          REPO: ${{ github.workspace }}
+          PAGES_BRANCH: gh-pages
+          SUBDIR: benchmarks
+          RECORD: ${{ github.ref_type != 'tag' && format('{0}/record/tachometer-record.json', runner.temp) || '' }}
+          JULIA_PROJECT: ${{ github.workspace }}/.tacho
+          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
+          PACKAGE_NAME: ${{ github.event.repository.name }}
+        run: |
+          script="$(julia --project=.tacho -e 'using Tachometer; print(joinpath(pkgdir(Tachometer), "scripts", "publish-timeseries.sh"))')"
+          bash "$script"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Copulas"
 uuid = "ae264745-0b69-425e-9d9d-cf662c5eec93"
-version = "0.1.38"
+version = "0.1.39"
 authors = ["Oskar Laverny"]
 
 [deps]

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,0 +1,9 @@
+[deps]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+Copulas = "ae264745-0b69-425e-9d9d-cf662c5eec93"
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+
+[compat]
+BenchmarkTools = "1"
+Distributions = "0.25"
+julia = "1"

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,137 @@
+using BenchmarkTools
+using Copulas
+using Distributions
+using Random
+
+# Tachometer runs the suite repeatedly for both revisions. One second per target
+# is sufficient for stable minima while keeping the complete CI job affordable.
+BenchmarkTools.DEFAULT_PARAMETERS.seconds = 1
+
+const SEED = 23
+const SUITE = BenchmarkGroup()
+
+SUITE["sampling"] = BenchmarkGroup()
+SUITE["density"] = BenchmarkGroup()
+SUITE["data"] = BenchmarkGroup()
+SUITE["conditioning"] = BenchmarkGroup()
+SUITE["fitting"] = BenchmarkGroup()
+
+# Each model below represents a distinct implementation path rather than every
+# possible family/dimension combination.
+clayton = ClaytonCopula(5, 2.0)
+gumbel = GumbelCopula(5, 2.0)
+
+rho = 0.35
+sigma = fill(rho, 10, 10)
+for i in axes(sigma, 1)
+    sigma[i, i] = 1.0
+end
+gaussian = GaussianCopula(sigma)
+
+nested = NestedArchimedeanCopula(Copulas.ClaytonGenerator(1.5);
+    leaves = [1, 2],
+    children = [
+        ClaytonCopula(2, 3.0),
+        ClaytonCopula(2, 2.5),
+    ],
+)
+
+archimax = ArchimaxCopula(
+    2,
+    Copulas.ClaytonGenerator(2.0),
+    Copulas.GalambosTail(1.5),
+)
+
+SUITE["sampling"]["clayton_d5"] = @benchmarkable(
+    rand(rng, $clayton, 10_000),
+    setup = (rng = Xoshiro(SEED)),
+    evals = 1,
+)
+SUITE["sampling"]["gaussian_d10"] = @benchmarkable(
+    rand(rng, $gaussian, 10_000),
+    setup = (rng = Xoshiro(SEED)),
+    evals = 1,
+)
+SUITE["sampling"]["nested_d6"] = @benchmarkable(
+    rand(rng, $nested, 100),
+    setup = (rng = Xoshiro(SEED)),
+    evals = 1,
+)
+SUITE["sampling"]["archimax_d2"] = @benchmarkable(
+    rand(rng, $archimax, 2_000),
+    setup = (rng = Xoshiro(SEED)),
+    evals = 1,
+)
+
+gumbel_points = rand(Xoshiro(SEED + 1), 5, 10_000)
+gaussian_points = rand(Xoshiro(SEED + 2), 10, 10_000)
+nested_points = rand(Xoshiro(SEED + 3), 6, 2_000)
+
+SUITE["density"]["gumbel_d5"] = @benchmarkable(
+    logpdf($gumbel, points),
+    setup = (points = $gumbel_points),
+    evals = 1,
+)
+SUITE["density"]["gaussian_d10"] = @benchmarkable(
+    logpdf($gaussian, points),
+    setup = (points = $gaussian_points),
+    evals = 1,
+)
+SUITE["density"]["nested_d6"] = @benchmarkable(
+    logpdf($nested, points),
+    setup = (points = $nested_points),
+    evals = 1,
+)
+
+raw_data = randn(Xoshiro(SEED + 4), 5, 10_000)
+checkerboard_data = randn(Xoshiro(SEED + 5), 3, 2_000)
+checkerboard = CheckerboardCopula(checkerboard_data; m=20, pseudo_values=false)
+checkerboard_points = rand(Xoshiro(SEED + 6), 3, 1_000)
+
+SUITE["data"]["pseudos_5x10000"] = @benchmarkable(
+    pseudos(data),
+    setup = (data = $raw_data),
+    evals = 1,
+)
+SUITE["data"]["checkerboard_cdf"] = @benchmarkable(
+    cdf($checkerboard, points),
+    setup = (points = $checkerboard_points),
+    evals = 1,
+)
+
+rosenblatt_copula = GaussianCopula(5, 0.35)
+rosenblatt_points = rand(Xoshiro(SEED + 7), 5, 2_000)
+SUITE["conditioning"]["rosenblatt_gaussian_d5"] = @benchmarkable(
+    rosenblatt($rosenblatt_copula, points),
+    setup = (points = $rosenblatt_points),
+    evals = 1,
+)
+
+gumbel_fit_data = rand(Xoshiro(SEED + 8), GumbelCopula(2, 2.0), 2_000)
+gaussian_fit_data = rand(Xoshiro(SEED + 9), GaussianCopula(3, 0.35), 1_000)
+sklar_model = SklarDist(
+    ClaytonCopula(3, 2.0),
+    (Normal(), LogNormal(0.0, 0.5), Gamma(2.0, 1.0)),
+)
+sklar_fit_data = rand(Xoshiro(SEED + 10), sklar_model, 1_000)
+
+SUITE["fitting"]["gumbel_itau"] = @benchmarkable(
+    fit(GumbelCopula, data; method=:itau),
+    setup = (data = $gumbel_fit_data),
+    evals = 1,
+)
+SUITE["fitting"]["gaussian_mle"] = @benchmarkable(
+    fit(GaussianCopula, data; method=:mle),
+    setup = (data = $gaussian_fit_data),
+    evals = 1,
+)
+SUITE["fitting"]["sklar_ifm"] = @benchmarkable(
+    fit(
+        SklarDist{ClaytonCopula,Tuple{Normal,LogNormal,Gamma}},
+        data;
+        sklar_method=:ifm,
+        copula_method=:mle,
+    ),
+    setup = (data = $sklar_fit_data),
+    evals = 1,
+)


### PR DESCRIPTION
Sets up a representative 13-target BenchmarkTools suite, fork-safe Tachometer PR reporting, default-branch performance tracking on GitHub Pages, and bumps Copulas.jl to v0.1.39. Tachometer is pinned to commit 334a994520a7e1c80167a5db1289d4f8f5d9c8d3. The complete suite was executed locally before opening this PR.