### PR TITLE
Add safeguarded smooth EV distortion quantiles

### DIFF
--- a/src/UnivariateDistribution/Distortions/BivEVDistortion.jl
+++ b/src/UnivariateDistribution/Distortions/BivEVDistortion.jl
@@ -91,3 +91,44 @@ function Distributions.logpdf(D::BivEVDistortion{TT,TF1}, z::Real) where {TT,TF1
         return logval + log(B)
     end
 end
+
+function Distributions.quantile(D::BivEVDistortion, α::Real)
+    T = promote_type(typeof(float(α)), typeof(D.uⱼ))
+    q = T(α)
+    zero(T) ≤ q ≤ one(T) || throw(ArgumentError("p must be between 0 and 1"))
+    iszero(q) && return zero(T)
+    isone(q) && return one(T)
+
+    logq = log(q)
+    lo, hi = -T(36), T(36)
+    z = zero(T)
+    bestz, bestres = z, T(Inf)
+
+    for _ in 1:(precision(T) + 16)
+        u = LogExpFunctions.logistic(z)
+        logF = Distributions.logcdf(D, u)
+        residual = logF - logq
+        absres = abs(residual)
+        if absres < bestres
+            bestz, bestres = z, absres
+        end
+        iszero(residual) && return u
+
+        if residual < zero(T)
+            lo = z
+        else
+            hi = z
+        end
+
+        logderivative = Distributions.logpdf(D, u) + log(u) + log1p(-u) - logF
+        derivative = exp(logderivative)
+        candidate = isfinite(derivative) && !iszero(derivative) ? z - residual / derivative : T(NaN)
+        if !isfinite(candidate) || !(lo < candidate < hi)
+            candidate = lo + (hi - lo) / T(2)
+        end
+        abs(hi - lo) ≤ T(16) * eps(T) * max(one(T), abs(candidate)) && break
+        z = candidate
+    end
+
+    return LogExpFunctions.logistic(bestz)
+end

--- a/test/ConditionalDistribution.jl
+++ b/test/ConditionalDistribution.jl
@@ -197,6 +197,19 @@ end
     @test DAM.invderivⱼ == Copulas.ϕ⁻¹⁽¹⁾(DAM.gen, DAM.uⱼ)
 end
 
+@testset "Smooth extreme-value distortion quantiles" begin
+    copulas = (
+        GalambosCopula(2, 2.5),
+        HuslerReissCopula(2, 0.6),
+        MixedCopula(2, 0.4),
+    )
+    for C in copulas, j in 1:2, base in (0.01, 0.3, 0.9), α in (1e-8, 0.2, 0.8, 1 - 1e-8)
+        D = condition(C, (j,), (base,))
+        u = quantile(D, α)
+        @test cdf(D, u) ≈ α atol=5e-10 rtol=5e-7
+    end
+end
+
 @testset "Archimedean distortion logcdf" begin
     distortions = (
         condition(ClaytonCopula(3, 2.0), (1, 2), (0.3, 0.6)),


### PR DESCRIPTION
Closes #380.

Adds a safeguarded Newton-bisection quantile for smooth BivEVDistortions in an unconstrained logit coordinate. It reuses the existing logcdf and logpdf kernels, so the Newton derivative is analytic without duplicating Pickands formulas. Existing family-specific generalized inverses for singular tails remain more specific dispatches.

Inspired by Santymax98/VineCopulas.jl commit 055fb1ad820640ab1092bd428e56ed7f05606568.