### PR TITLE
Expand Tachometer benchmark coverage

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -3,22 +3,72 @@ using Copulas
 using Distributions
 using Random
 
-# Tachometer runs the suite repeatedly for both revisions. One second per target
-# is sufficient for stable minima while keeping the complete CI job affordable.
 BenchmarkTools.DEFAULT_PARAMETERS.seconds = 1
 
 const SEED = 23
 const SUITE = BenchmarkGroup()
 
-SUITE["sampling"] = BenchmarkGroup()
-SUITE["density"] = BenchmarkGroup()
-SUITE["cdf"] = BenchmarkGroup()
-SUITE["data"] = BenchmarkGroup()
-SUITE["conditioning"] = BenchmarkGroup()
-SUITE["fitting"] = BenchmarkGroup()
+bench_name(C) = lowercase(replace(string(nameof(typeof(C))), "Copula" => "")) * "_d$(length(C))"
+bench_group!(suite, operation) = get!(suite, operation, BenchmarkGroup())
 
-# Each model below represents a distinct implementation path rather than every
-# possible family/dimension combination.
+function bench_sampling!(suite, C, n)
+    bench_group!(suite, "sampling")[bench_name(C)] = @benchmarkable(
+        rand(rng, $C, $n),
+        setup=(rng = Xoshiro(SEED)),
+        evals=1,
+    )
+end
+
+function bench_logpdf!(suite, C, points)
+    bench_group!(suite, "logpdf")[bench_name(C)] =
+        @benchmarkable logpdf($C, $points) evals=1
+end
+
+function bench_cdf!(suite, C, points)
+    bench_group!(suite, "cdf")[bench_name(C)] =
+        @benchmarkable cdf($C, $points) evals=1
+end
+
+function bench_rosenblatt!(suite, C, points)
+    bench_group!(suite, "rosenblatt")[bench_name(C)] =
+        @benchmarkable rosenblatt($C, $points) evals=1
+end
+
+function bench_inverse_rosenblatt!(suite, C, points)
+    bench_group!(suite, "inverse_rosenblatt")[bench_name(C)] =
+        @benchmarkable inverse_rosenblatt($C, $points) evals=1
+end
+
+function bench_condition!(suite, C, j, values)
+    bench_group!(suite, "condition")[bench_name(C)] = @benchmarkable(
+        [condition($C, $j, u) for u in $values],
+        evals=1,
+    )
+end
+
+function bench_conditional_cdf!(suite, C, j, base, points)
+    D = condition(C, j, base)
+    bench_group!(suite, "conditional_cdf")[bench_name(C)] =
+        @benchmarkable cdf($D, $points) evals=1
+end
+
+function bench_conditional_quantile!(suite, C, j, base, probabilities)
+    D = condition(C, j, base)
+    bench_group!(suite, "conditional_quantile")[bench_name(C)] =
+        @benchmarkable quantile($D, $probabilities) evals=1
+end
+
+function bench_pseudos!(suite, data)
+    name = "matrix_$(size(data, 1))x$(size(data, 2))"
+    bench_group!(suite, "pseudos")[name] = @benchmarkable pseudos($data) evals=1
+end
+
+function bench_fitting!(suite, name, model, data; kwargs...)
+    workload = () -> fit(model, data; kwargs...)
+    bench_group!(suite, "fitting")[name] = @benchmarkable $workload() evals=1
+end
+
+# Representative models: each one exercises a distinct implementation path.
 clayton = ClaytonCopula(5, 2.0)
 gumbel = GumbelCopula(5, 2.0)
 
@@ -30,94 +80,34 @@ end
 gaussian = GaussianCopula(sigma)
 
 nested = NestedArchimedeanCopula(Copulas.ClaytonGenerator(1.5);
-    leaves = [1, 2],
-    children = [
-        ClaytonCopula(2, 3.0),
-        ClaytonCopula(2, 2.5),
-    ],
+    leaves=[1, 2],
+    children=[ClaytonCopula(2, 3.0), ClaytonCopula(2, 2.5)],
 )
-
-archimax = ArchimaxCopula(
-    2,
-    Copulas.ClaytonGenerator(2.0),
-    Copulas.GalambosTail(1.5),
-)
+archimax = ArchimaxCopula(2, Copulas.ClaytonGenerator(2.0), Copulas.GalambosTail(1.5))
 student = TCopula(4, [1.0 0.5; 0.5 1.0])
 bb1 = BB1Copula(2, 1.2, 1.5)
 galambos = GalambosCopula(2, 1.5)
 
-SUITE["sampling"]["clayton_d5"] = @benchmarkable(
-    rand(rng, $clayton, 10_000),
-    setup = (rng = Xoshiro(SEED)),
-    evals = 1,
-)
-SUITE["sampling"]["gaussian_d10"] = @benchmarkable(
-    rand(rng, $gaussian, 10_000),
-    setup = (rng = Xoshiro(SEED)),
-    evals = 1,
-)
-SUITE["sampling"]["nested_d6"] = @benchmarkable(
-    rand(rng, $nested, 100),
-    setup = (rng = Xoshiro(SEED)),
-    evals = 1,
-)
-SUITE["sampling"]["archimax_d2"] = @benchmarkable(
-    rand(rng, $archimax, 2_000),
-    setup = (rng = Xoshiro(SEED)),
-    evals = 1,
-)
-SUITE["sampling"]["student_d2"] = @benchmarkable(
-    rand(rng, $student, 10_000),
-    setup = (rng = Xoshiro(SEED)),
-    evals = 1,
-)
-SUITE["sampling"]["galambos_d2"] = @benchmarkable(
-    rand(rng, $galambos, 10_000),
-    setup = (rng = Xoshiro(SEED)),
-    evals = 1,
-)
+bench_sampling!(SUITE, clayton, 10_000)
+bench_sampling!(SUITE, gaussian, 10_000)
+bench_sampling!(SUITE, nested, 100)
+bench_sampling!(SUITE, archimax, 2_000)
+bench_sampling!(SUITE, student, 10_000)
+bench_sampling!(SUITE, galambos, 10_000)
 
 gumbel_points = rand(Xoshiro(SEED + 1), 5, 10_000)
 gaussian_points = rand(Xoshiro(SEED + 2), 10, 10_000)
 nested_points = rand(Xoshiro(SEED + 3), 6, 2_000)
 pair_points = clamp.(rand(Xoshiro(SEED + 11), 2, 10_000), 1e-6, 1 - 1e-6)
 
-SUITE["density"]["gumbel_d5"] = @benchmarkable(
-    logpdf($gumbel, points),
-    setup = (points = $gumbel_points),
-    evals = 1,
-)
-SUITE["density"]["gaussian_d10"] = @benchmarkable(
-    logpdf($gaussian, points),
-    setup = (points = $gaussian_points),
-    evals = 1,
-)
-SUITE["density"]["nested_d6"] = @benchmarkable(
-    logpdf($nested, points),
-    setup = (points = $nested_points),
-    evals = 1,
-)
-SUITE["density"]["bb1_d2"] = @benchmarkable(
-    logpdf($bb1, points),
-    setup = (points = $pair_points),
-    evals = 1,
-)
-SUITE["density"]["galambos_d2"] = @benchmarkable(
-    logpdf($galambos, points),
-    setup = (points = $pair_points),
-    evals = 1,
-)
+bench_logpdf!(SUITE, gumbel, gumbel_points)
+bench_logpdf!(SUITE, gaussian, gaussian_points)
+bench_logpdf!(SUITE, nested, nested_points)
+bench_logpdf!(SUITE, bb1, pair_points)
+bench_logpdf!(SUITE, galambos, pair_points)
 
-SUITE["cdf"]["bb1_d2"] = @benchmarkable(
-    cdf($bb1, points),
-    setup = (points = $pair_points),
-    evals = 1,
-)
-SUITE["cdf"]["galambos_d2"] = @benchmarkable(
-    cdf($galambos, points),
-    setup = (points = $pair_points),
-    evals = 1,
-)
+bench_cdf!(SUITE, bb1, pair_points)
+bench_cdf!(SUITE, galambos, pair_points)
 
 raw_data = randn(Xoshiro(SEED + 4), 5, 10_000)
 checkerboard_data = randn(Xoshiro(SEED + 5), 3, 2_000)
@@ -128,59 +118,20 @@ empirical = EmpiricalCopula(empirical_data; pseudo_values=false)
 beta = BetaCopula(empirical_data)
 empirical_points = rand(Xoshiro(SEED + 13), 2, 1_000)
 
-SUITE["data"]["pseudos_5x10000"] = @benchmarkable(
-    pseudos(data),
-    setup = (data = $raw_data),
-    evals = 1,
-)
-SUITE["data"]["checkerboard_cdf"] = @benchmarkable(
-    cdf($checkerboard, points),
-    setup = (points = $checkerboard_points),
-    evals = 1,
-)
-SUITE["data"]["empirical_cdf"] = @benchmarkable(
-    cdf($empirical, points),
-    setup = (points = $empirical_points),
-    evals = 1,
-)
-SUITE["data"]["beta_logpdf"] = @benchmarkable(
-    logpdf($beta, points),
-    setup = (points = $empirical_points),
-    evals = 1,
-)
+bench_pseudos!(SUITE, raw_data)
+bench_cdf!(SUITE, checkerboard, checkerboard_points)
+bench_cdf!(SUITE, empirical, empirical_points)
+bench_logpdf!(SUITE, beta, empirical_points)
 
 rosenblatt_copula = GaussianCopula(5, 0.35)
 rosenblatt_points = rand(Xoshiro(SEED + 7), 5, 2_000)
-SUITE["conditioning"]["rosenblatt_gaussian_d5"] = @benchmarkable(
-    rosenblatt($rosenblatt_copula, points),
-    setup = (points = $rosenblatt_points),
-    evals = 1,
-)
-SUITE["conditioning"]["inverse_rosenblatt_gaussian_d5"] = @benchmarkable(
-    inverse_rosenblatt($rosenblatt_copula, points),
-    setup = (points = $rosenblatt_points),
-    evals = 1,
-)
+bench_rosenblatt!(SUITE, rosenblatt_copula, rosenblatt_points)
+bench_inverse_rosenblatt!(SUITE, rosenblatt_copula, rosenblatt_points)
 
-bb1_distortion = condition(bb1, 2, 0.4)
-galambos_distortion = condition(galambos, 2, 0.4)
 conditional_probabilities = collect(range(1e-5, 1 - 1e-5; length=1_000))
-
-SUITE["conditioning"]["construct_bb1_d2_1000"] = @benchmarkable(
-    [condition($bb1, 2, u) for u in probabilities],
-    setup = (probabilities = $conditional_probabilities),
-    evals = 1,
-)
-SUITE["conditioning"]["cdf_bb1_d2"] = @benchmarkable(
-    cdf($bb1_distortion, probabilities),
-    setup = (probabilities = $conditional_probabilities),
-    evals = 1,
-)
-SUITE["conditioning"]["quantile_galambos_d2"] = @benchmarkable(
-    quantile($galambos_distortion, probabilities),
-    setup = (probabilities = $conditional_probabilities),
-    evals = 1,
-)
+bench_condition!(SUITE, bb1, 2, conditional_probabilities)
+bench_conditional_cdf!(SUITE, bb1, 2, 0.4, conditional_probabilities)
+bench_conditional_quantile!(SUITE, galambos, 2, 0.4, conditional_probabilities)
 
 gumbel_fit_data = rand(Xoshiro(SEED + 8), GumbelCopula(2, 2.0), 2_000)
 gaussian_fit_data = rand(Xoshiro(SEED + 9), GaussianCopula(3, 0.35), 1_000)
@@ -190,23 +141,13 @@ sklar_model = SklarDist(
 )
 sklar_fit_data = rand(Xoshiro(SEED + 10), sklar_model, 1_000)
 
-SUITE["fitting"]["gumbel_itau"] = @benchmarkable(
-    fit(GumbelCopula, data; method=:itau),
-    setup = (data = $gumbel_fit_data),
-    evals = 1,
-)
-SUITE["fitting"]["gaussian_mle"] = @benchmarkable(
-    fit(GaussianCopula, data; method=:mle),
-    setup = (data = $gaussian_fit_data),
-    evals = 1,
-)
-SUITE["fitting"]["sklar_ifm"] = @benchmarkable(
-    fit(
-        SklarDist{ClaytonCopula,Tuple{Normal,LogNormal,Gamma}},
-        data;
-        sklar_method=:ifm,
-        copula_method=:mle,
-    ),
-    setup = (data = $sklar_fit_data),
-    evals = 1,
+bench_fitting!(SUITE, "gumbel_itau", GumbelCopula, gumbel_fit_data; method=:itau)
+bench_fitting!(SUITE, "gaussian_mle", GaussianCopula, gaussian_fit_data; method=:mle)
+bench_fitting!(
+    SUITE,
+    "sklar_ifm",
+    SklarDist{ClaytonCopula,Tuple{Normal,LogNormal,Gamma}},
+    sklar_fit_data;
+    sklar_method=:ifm,
+    copula_method=:mle,
 )

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -12,6 +12,7 @@ const SUITE = BenchmarkGroup()
 
 SUITE["sampling"] = BenchmarkGroup()
 SUITE["density"] = BenchmarkGroup()
+SUITE["cdf"] = BenchmarkGroup()
 SUITE["data"] = BenchmarkGroup()
 SUITE["conditioning"] = BenchmarkGroup()
 SUITE["fitting"] = BenchmarkGroup()
@@ -41,6 +42,9 @@ archimax = ArchimaxCopula(
     Copulas.ClaytonGenerator(2.0),
     Copulas.GalambosTail(1.5),
 )
+student = TCopula(4, [1.0 0.5; 0.5 1.0])
+bb1 = BB1Copula(2, 1.2, 1.5)
+galambos = GalambosCopula(2, 1.5)
 
 SUITE["sampling"]["clayton_d5"] = @benchmarkable(
     rand(rng, $clayton, 10_000),
@@ -62,10 +66,21 @@ SUITE["sampling"]["archimax_d2"] = @benchmarkable(
     setup = (rng = Xoshiro(SEED)),
     evals = 1,
 )
+SUITE["sampling"]["student_d2"] = @benchmarkable(
+    rand(rng, $student, 10_000),
+    setup = (rng = Xoshiro(SEED)),
+    evals = 1,
+)
+SUITE["sampling"]["galambos_d2"] = @benchmarkable(
+    rand(rng, $galambos, 10_000),
+    setup = (rng = Xoshiro(SEED)),
+    evals = 1,
+)
 
 gumbel_points = rand(Xoshiro(SEED + 1), 5, 10_000)
 gaussian_points = rand(Xoshiro(SEED + 2), 10, 10_000)
 nested_points = rand(Xoshiro(SEED + 3), 6, 2_000)
+pair_points = clamp.(rand(Xoshiro(SEED + 11), 2, 10_000), 1e-6, 1 - 1e-6)
 
 SUITE["density"]["gumbel_d5"] = @benchmarkable(
     logpdf($gumbel, points),
@@ -82,11 +97,36 @@ SUITE["density"]["nested_d6"] = @benchmarkable(
     setup = (points = $nested_points),
     evals = 1,
 )
+SUITE["density"]["bb1_d2"] = @benchmarkable(
+    logpdf($bb1, points),
+    setup = (points = $pair_points),
+    evals = 1,
+)
+SUITE["density"]["galambos_d2"] = @benchmarkable(
+    logpdf($galambos, points),
+    setup = (points = $pair_points),
+    evals = 1,
+)
+
+SUITE["cdf"]["bb1_d2"] = @benchmarkable(
+    cdf($bb1, points),
+    setup = (points = $pair_points),
+    evals = 1,
+)
+SUITE["cdf"]["galambos_d2"] = @benchmarkable(
+    cdf($galambos, points),
+    setup = (points = $pair_points),
+    evals = 1,
+)
 
 raw_data = randn(Xoshiro(SEED + 4), 5, 10_000)
 checkerboard_data = randn(Xoshiro(SEED + 5), 3, 2_000)
 checkerboard = CheckerboardCopula(checkerboard_data; m=20, pseudo_values=false)
 checkerboard_points = rand(Xoshiro(SEED + 6), 3, 1_000)
+empirical_data = randn(Xoshiro(SEED + 12), 2, 2_000)
+empirical = EmpiricalCopula(empirical_data; pseudo_values=false)
+beta = BetaCopula(empirical_data)
+empirical_points = rand(Xoshiro(SEED + 13), 2, 1_000)
 
 SUITE["data"]["pseudos_5x10000"] = @benchmarkable(
     pseudos(data),
@@ -98,12 +138,47 @@ SUITE["data"]["checkerboard_cdf"] = @benchmarkable(
     setup = (points = $checkerboard_points),
     evals = 1,
 )
+SUITE["data"]["empirical_cdf"] = @benchmarkable(
+    cdf($empirical, points),
+    setup = (points = $empirical_points),
+    evals = 1,
+)
+SUITE["data"]["beta_logpdf"] = @benchmarkable(
+    logpdf($beta, points),
+    setup = (points = $empirical_points),
+    evals = 1,
+)
 
 rosenblatt_copula = GaussianCopula(5, 0.35)
 rosenblatt_points = rand(Xoshiro(SEED + 7), 5, 2_000)
 SUITE["conditioning"]["rosenblatt_gaussian_d5"] = @benchmarkable(
     rosenblatt($rosenblatt_copula, points),
     setup = (points = $rosenblatt_points),
+    evals = 1,
+)
+SUITE["conditioning"]["inverse_rosenblatt_gaussian_d5"] = @benchmarkable(
+    inverse_rosenblatt($rosenblatt_copula, points),
+    setup = (points = $rosenblatt_points),
+    evals = 1,
+)
+
+bb1_distortion = condition(bb1, 2, 0.4)
+galambos_distortion = condition(galambos, 2, 0.4)
+conditional_probabilities = collect(range(1e-5, 1 - 1e-5; length=1_000))
+
+SUITE["conditioning"]["construct_bb1_d2_1000"] = @benchmarkable(
+    [condition($bb1, 2, u) for u in probabilities],
+    setup = (probabilities = $conditional_probabilities),
+    evals = 1,
+)
+SUITE["conditioning"]["cdf_bb1_d2"] = @benchmarkable(
+    cdf($bb1_distortion, probabilities),
+    setup = (probabilities = $conditional_probabilities),
+    evals = 1,
+)
+SUITE["conditioning"]["quantile_galambos_d2"] = @benchmarkable(
+    quantile($galambos_distortion, probabilities),
+    setup = (probabilities = $conditional_probabilities),
     evals = 1,
 )
 

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -14,56 +14,55 @@ function bench_group!(suite, operation)
     return suite[operation]
 end
 
-function bench_sampling!(suite, C, n)
-    bench_group!(suite, "sampling")[bench_name(C)] = @benchmarkable(
+function bench_sampling!(suite, C, n; name=bench_name(C), group="sampling")
+    bench_group!(suite, group)[name] = @benchmarkable(
         rand(rng, $C, $n),
         setup=(rng = Xoshiro(SEED)),
         evals=1,
     )
 end
 
-function bench_logpdf!(suite, C, points)
-    bench_group!(suite, "logpdf")[bench_name(C)] =
+function bench_logpdf!(suite, C, points; name=bench_name(C), group="logpdf")
+    bench_group!(suite, group)[name] =
         @benchmarkable logpdf($C, $points) evals=1
 end
 
-function bench_cdf!(suite, C, points)
-    bench_group!(suite, "cdf")[bench_name(C)] =
+function bench_cdf!(suite, C, points; name=bench_name(C), group="cdf")
+    bench_group!(suite, group)[name] =
         @benchmarkable cdf($C, $points) evals=1
 end
 
-function bench_rosenblatt!(suite, C, points)
-    bench_group!(suite, "rosenblatt")[bench_name(C)] =
+function bench_rosenblatt!(suite, C, points; name=bench_name(C), group="rosenblatt")
+    bench_group!(suite, group)[name] =
         @benchmarkable rosenblatt($C, $points) evals=1
 end
 
-function bench_inverse_rosenblatt!(suite, C, points)
-    bench_group!(suite, "inverse_rosenblatt")[bench_name(C)] =
+function bench_inverse_rosenblatt!(suite, C, points; name=bench_name(C), group="inverse_rosenblatt")
+    bench_group!(suite, group)[name] =
         @benchmarkable inverse_rosenblatt($C, $points) evals=1
 end
 
-function bench_condition!(suite, C, j, values)
-    bench_group!(suite, "condition")[bench_name(C)] = @benchmarkable(
+function bench_condition!(suite, C, j, values; name=bench_name(C), group="condition")
+    bench_group!(suite, group)[name] = @benchmarkable(
         [condition($C, $j, u) for u in $values],
         evals=1,
     )
 end
 
-function bench_conditional_cdf!(suite, C, j, base, points)
+function bench_conditional_cdf!(suite, C, j, base, points; name=bench_name(C), group="conditional_cdf")
     D = condition(C, j, base)
-    bench_group!(suite, "conditional_cdf")[bench_name(C)] =
+    bench_group!(suite, group)[name] =
         @benchmarkable cdf($D, $points) evals=1
 end
 
-function bench_conditional_quantile!(suite, C, j, base, probabilities)
+function bench_conditional_quantile!(suite, C, j, base, probabilities; name=bench_name(C), group="conditional_quantile")
     D = condition(C, j, base)
-    bench_group!(suite, "conditional_quantile")[bench_name(C)] =
+    bench_group!(suite, group)[name] =
         @benchmarkable quantile($D, $probabilities) evals=1
 end
 
-function bench_pseudos!(suite, data)
-    name = "matrix_$(size(data, 1))x$(size(data, 2))"
-    bench_group!(suite, "pseudos")[name] = @benchmarkable pseudos($data) evals=1
+function bench_pseudos!(suite, data; name="matrix_$(size(data, 1))x$(size(data, 2))", group="pseudos")
+    bench_group!(suite, group)[name] = @benchmarkable pseudos($data) evals=1
 end
 
 function bench_fitting!(suite, name, model, data; kwargs...)
@@ -91,26 +90,26 @@ student = TCopula(4, [1.0 0.5; 0.5 1.0])
 bb1 = BB1Copula(2, 1.2, 1.5)
 galambos = GalambosCopula(2, 1.5)
 
-bench_sampling!(SUITE, clayton, 10_000)
+bench_sampling!(SUITE, clayton, 10_000; name="clayton_d5")
 bench_sampling!(SUITE, gaussian, 10_000)
-bench_sampling!(SUITE, nested, 100)
+bench_sampling!(SUITE, nested, 100; name="nested_d6")
 bench_sampling!(SUITE, archimax, 2_000)
-bench_sampling!(SUITE, student, 10_000)
-bench_sampling!(SUITE, galambos, 10_000)
+bench_sampling!(SUITE, student, 10_000; name="student_d2")
+bench_sampling!(SUITE, galambos, 10_000; name="galambos_d2")
 
 gumbel_points = rand(Xoshiro(SEED + 1), 5, 10_000)
 gaussian_points = rand(Xoshiro(SEED + 2), 10, 10_000)
 nested_points = rand(Xoshiro(SEED + 3), 6, 2_000)
 pair_points = clamp.(rand(Xoshiro(SEED + 11), 2, 10_000), 1e-6, 1 - 1e-6)
 
-bench_logpdf!(SUITE, gumbel, gumbel_points)
-bench_logpdf!(SUITE, gaussian, gaussian_points)
-bench_logpdf!(SUITE, nested, nested_points)
-bench_logpdf!(SUITE, bb1, pair_points)
-bench_logpdf!(SUITE, galambos, pair_points)
+bench_logpdf!(SUITE, gumbel, gumbel_points; name="gumbel_d5", group="density")
+bench_logpdf!(SUITE, gaussian, gaussian_points; name="gaussian_d10", group="density")
+bench_logpdf!(SUITE, nested, nested_points; name="nested_d6", group="density")
+bench_logpdf!(SUITE, bb1, pair_points; name="bb1_d2", group="density")
+bench_logpdf!(SUITE, galambos, pair_points; name="galambos_d2", group="density")
 
-bench_cdf!(SUITE, bb1, pair_points)
-bench_cdf!(SUITE, galambos, pair_points)
+bench_cdf!(SUITE, bb1, pair_points; name="bb1_d2")
+bench_cdf!(SUITE, galambos, pair_points; name="galambos_d2")
 
 raw_data = randn(Xoshiro(SEED + 4), 5, 10_000)
 checkerboard_data = randn(Xoshiro(SEED + 5), 3, 2_000)
@@ -121,20 +120,20 @@ empirical = EmpiricalCopula(empirical_data; pseudo_values=false)
 beta = BetaCopula(empirical_data)
 empirical_points = rand(Xoshiro(SEED + 13), 2, 1_000)
 
-bench_pseudos!(SUITE, raw_data)
-bench_cdf!(SUITE, checkerboard, checkerboard_points)
-bench_cdf!(SUITE, empirical, empirical_points)
-bench_logpdf!(SUITE, beta, empirical_points)
+bench_pseudos!(SUITE, raw_data; name="pseudos_5x10000", group="data")
+bench_cdf!(SUITE, checkerboard, checkerboard_points; name="checkerboard_cdf", group="data")
+bench_cdf!(SUITE, empirical, empirical_points; name="empirical_cdf", group="data")
+bench_logpdf!(SUITE, beta, empirical_points; name="beta_logpdf", group="data")
 
 rosenblatt_copula = GaussianCopula(5, 0.35)
 rosenblatt_points = rand(Xoshiro(SEED + 7), 5, 2_000)
-bench_rosenblatt!(SUITE, rosenblatt_copula, rosenblatt_points)
-bench_inverse_rosenblatt!(SUITE, rosenblatt_copula, rosenblatt_points)
+bench_rosenblatt!(SUITE, rosenblatt_copula, rosenblatt_points; name="rosenblatt_gaussian_d5", group="conditioning")
+bench_inverse_rosenblatt!(SUITE, rosenblatt_copula, rosenblatt_points; name="inverse_rosenblatt_gaussian_d5", group="conditioning")
 
 conditional_probabilities = collect(range(1e-5, 1 - 1e-5; length=1_000))
-bench_condition!(SUITE, bb1, 2, conditional_probabilities)
-bench_conditional_cdf!(SUITE, bb1, 2, 0.4, conditional_probabilities)
-bench_conditional_quantile!(SUITE, galambos, 2, 0.4, conditional_probabilities)
+bench_condition!(SUITE, bb1, 2, conditional_probabilities; name="construct_bb1_d2_1000", group="conditioning")
+bench_conditional_cdf!(SUITE, bb1, 2, 0.4, conditional_probabilities; name="cdf_bb1_d2", group="conditioning")
+bench_conditional_quantile!(SUITE, galambos, 2, 0.4, conditional_probabilities; name="quantile_galambos_d2", group="conditioning")
 
 gumbel_fit_data = rand(Xoshiro(SEED + 8), GumbelCopula(2, 2.0), 2_000)
 gaussian_fit_data = rand(Xoshiro(SEED + 9), GaussianCopula(3, 0.35), 1_000)

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -8,67 +8,62 @@ BenchmarkTools.DEFAULT_PARAMETERS.seconds = 1
 const SEED = 23
 const SUITE = BenchmarkGroup()
 
-bench_name(C) = lowercase(replace(string(nameof(typeof(C))), "Copula" => "")) * "_d$(length(C))"
-function bench_group!(suite, operation)
-    haskey(suite, operation) || (suite[operation] = BenchmarkGroup())
-    return suite[operation]
-end
-
-function bench_sampling!(suite, C, n; name=bench_name(C), group="sampling")
-    bench_group!(suite, group)[name] = @benchmarkable(
+function bench_sampling(C, n)
+    return @benchmarkable(
         rand(rng, $C, $n),
         setup=(rng = Xoshiro(SEED)),
         evals=1,
     )
 end
 
-function bench_logpdf!(suite, C, points; name=bench_name(C), group="logpdf")
-    bench_group!(suite, group)[name] =
-        @benchmarkable logpdf($C, $points) evals=1
+function bench_logpdf(C, points)
+    return @benchmarkable logpdf($C, $points) evals=1
 end
 
-function bench_cdf!(suite, C, points; name=bench_name(C), group="cdf")
-    bench_group!(suite, group)[name] =
-        @benchmarkable cdf($C, $points) evals=1
+function bench_cdf(C, points)
+    return @benchmarkable cdf($C, $points) evals=1
 end
 
-function bench_rosenblatt!(suite, C, points; name=bench_name(C), group="rosenblatt")
-    bench_group!(suite, group)[name] =
-        @benchmarkable rosenblatt($C, $points) evals=1
+function bench_rosenblatt(C, points)
+    return @benchmarkable rosenblatt($C, $points) evals=1
 end
 
-function bench_inverse_rosenblatt!(suite, C, points; name=bench_name(C), group="inverse_rosenblatt")
-    bench_group!(suite, group)[name] =
-        @benchmarkable inverse_rosenblatt($C, $points) evals=1
+function bench_inverse_rosenblatt(C, points)
+    return @benchmarkable inverse_rosenblatt($C, $points) evals=1
 end
 
-function bench_condition!(suite, C, j, values; name=bench_name(C), group="condition")
-    bench_group!(suite, group)[name] = @benchmarkable(
+function bench_condition(C, j, values)
+    return @benchmarkable(
         [condition($C, $j, u) for u in $values],
         evals=1,
     )
 end
 
-function bench_conditional_cdf!(suite, C, j, base, points; name=bench_name(C), group="conditional_cdf")
+function bench_conditional_cdf(C, j, base, points)
     D = condition(C, j, base)
-    bench_group!(suite, group)[name] =
-        @benchmarkable cdf($D, $points) evals=1
+    return @benchmarkable cdf($D, $points) evals=1
 end
 
-function bench_conditional_quantile!(suite, C, j, base, probabilities; name=bench_name(C), group="conditional_quantile")
+function bench_conditional_quantile(C, j, base, probabilities)
     D = condition(C, j, base)
-    bench_group!(suite, group)[name] =
-        @benchmarkable quantile($D, $probabilities) evals=1
+    return @benchmarkable quantile($D, $probabilities) evals=1
 end
 
-function bench_pseudos!(suite, data; name="matrix_$(size(data, 1))x$(size(data, 2))", group="pseudos")
-    bench_group!(suite, group)[name] = @benchmarkable pseudos($data) evals=1
+function bench_pseudos(data)
+    return @benchmarkable pseudos($data) evals=1
 end
 
-function bench_fitting!(suite, name, model, data; kwargs...)
+function bench_fitting(model, data; kwargs...)
     workload = () -> fit(model, data; kwargs...)
-    bench_group!(suite, "fitting")[name] = @benchmarkable $workload() evals=1
+    return @benchmarkable $workload() evals=1
 end
+
+SUITE["sampling"] = BenchmarkGroup()
+SUITE["density"] = BenchmarkGroup()
+SUITE["cdf"] = BenchmarkGroup()
+SUITE["data"] = BenchmarkGroup()
+SUITE["conditioning"] = BenchmarkGroup()
+SUITE["fitting"] = BenchmarkGroup()
 
 # Representative models: each one exercises a distinct implementation path.
 clayton = ClaytonCopula(5, 2.0)
@@ -90,26 +85,26 @@ student = TCopula(4, [1.0 0.5; 0.5 1.0])
 bb1 = BB1Copula(2, 1.2, 1.5)
 galambos = GalambosCopula(2, 1.5)
 
-bench_sampling!(SUITE, clayton, 10_000; name="clayton_d5")
-bench_sampling!(SUITE, gaussian, 10_000)
-bench_sampling!(SUITE, nested, 100; name="nested_d6")
-bench_sampling!(SUITE, archimax, 2_000)
-bench_sampling!(SUITE, student, 10_000; name="student_d2")
-bench_sampling!(SUITE, galambos, 10_000; name="galambos_d2")
+SUITE["sampling"]["clayton_d5"] = bench_sampling(clayton, 10_000)
+SUITE["sampling"]["gaussian_d10"] = bench_sampling(gaussian, 10_000)
+SUITE["sampling"]["nested_d6"] = bench_sampling(nested, 100)
+SUITE["sampling"]["archimax_d2"] = bench_sampling(archimax, 2_000)
+SUITE["sampling"]["student_d2"] = bench_sampling(student, 10_000)
+SUITE["sampling"]["galambos_d2"] = bench_sampling(galambos, 10_000)
 
 gumbel_points = rand(Xoshiro(SEED + 1), 5, 10_000)
 gaussian_points = rand(Xoshiro(SEED + 2), 10, 10_000)
 nested_points = rand(Xoshiro(SEED + 3), 6, 2_000)
 pair_points = clamp.(rand(Xoshiro(SEED + 11), 2, 10_000), 1e-6, 1 - 1e-6)
 
-bench_logpdf!(SUITE, gumbel, gumbel_points; name="gumbel_d5", group="density")
-bench_logpdf!(SUITE, gaussian, gaussian_points; name="gaussian_d10", group="density")
-bench_logpdf!(SUITE, nested, nested_points; name="nested_d6", group="density")
-bench_logpdf!(SUITE, bb1, pair_points; name="bb1_d2", group="density")
-bench_logpdf!(SUITE, galambos, pair_points; name="galambos_d2", group="density")
+SUITE["density"]["gumbel_d5"] = bench_logpdf(gumbel, gumbel_points)
+SUITE["density"]["gaussian_d10"] = bench_logpdf(gaussian, gaussian_points)
+SUITE["density"]["nested_d6"] = bench_logpdf(nested, nested_points)
+SUITE["density"]["bb1_d2"] = bench_logpdf(bb1, pair_points)
+SUITE["density"]["galambos_d2"] = bench_logpdf(galambos, pair_points)
 
-bench_cdf!(SUITE, bb1, pair_points; name="bb1_d2")
-bench_cdf!(SUITE, galambos, pair_points; name="galambos_d2")
+SUITE["cdf"]["bb1_d2"] = bench_cdf(bb1, pair_points)
+SUITE["cdf"]["galambos_d2"] = bench_cdf(galambos, pair_points)
 
 raw_data = randn(Xoshiro(SEED + 4), 5, 10_000)
 checkerboard_data = randn(Xoshiro(SEED + 5), 3, 2_000)
@@ -120,20 +115,25 @@ empirical = EmpiricalCopula(empirical_data; pseudo_values=false)
 beta = BetaCopula(empirical_data)
 empirical_points = rand(Xoshiro(SEED + 13), 2, 1_000)
 
-bench_pseudos!(SUITE, raw_data; name="pseudos_5x10000", group="data")
-bench_cdf!(SUITE, checkerboard, checkerboard_points; name="checkerboard_cdf", group="data")
-bench_cdf!(SUITE, empirical, empirical_points; name="empirical_cdf", group="data")
-bench_logpdf!(SUITE, beta, empirical_points; name="beta_logpdf", group="data")
+SUITE["data"]["pseudos_5x10000"] = bench_pseudos(raw_data)
+SUITE["data"]["checkerboard_cdf"] = bench_cdf(checkerboard, checkerboard_points)
+SUITE["data"]["empirical_cdf"] = bench_cdf(empirical, empirical_points)
+SUITE["data"]["beta_logpdf"] = bench_logpdf(beta, empirical_points)
 
 rosenblatt_copula = GaussianCopula(5, 0.35)
 rosenblatt_points = rand(Xoshiro(SEED + 7), 5, 2_000)
-bench_rosenblatt!(SUITE, rosenblatt_copula, rosenblatt_points; name="rosenblatt_gaussian_d5", group="conditioning")
-bench_inverse_rosenblatt!(SUITE, rosenblatt_copula, rosenblatt_points; name="inverse_rosenblatt_gaussian_d5", group="conditioning")
+SUITE["conditioning"]["rosenblatt_gaussian_d5"] =
+    bench_rosenblatt(rosenblatt_copula, rosenblatt_points)
+SUITE["conditioning"]["inverse_rosenblatt_gaussian_d5"] =
+    bench_inverse_rosenblatt(rosenblatt_copula, rosenblatt_points)
 
 conditional_probabilities = collect(range(1e-5, 1 - 1e-5; length=1_000))
-bench_condition!(SUITE, bb1, 2, conditional_probabilities; name="construct_bb1_d2_1000", group="conditioning")
-bench_conditional_cdf!(SUITE, bb1, 2, 0.4, conditional_probabilities; name="cdf_bb1_d2", group="conditioning")
-bench_conditional_quantile!(SUITE, galambos, 2, 0.4, conditional_probabilities; name="quantile_galambos_d2", group="conditioning")
+SUITE["conditioning"]["construct_bb1_d2_1000"] =
+    bench_condition(bb1, 2, conditional_probabilities)
+SUITE["conditioning"]["cdf_bb1_d2"] =
+    bench_conditional_cdf(bb1, 2, 0.4, conditional_probabilities)
+SUITE["conditioning"]["quantile_galambos_d2"] =
+    bench_conditional_quantile(galambos, 2, 0.4, conditional_probabilities)
 
 gumbel_fit_data = rand(Xoshiro(SEED + 8), GumbelCopula(2, 2.0), 2_000)
 gaussian_fit_data = rand(Xoshiro(SEED + 9), GaussianCopula(3, 0.35), 1_000)
@@ -143,11 +143,9 @@ sklar_model = SklarDist(
 )
 sklar_fit_data = rand(Xoshiro(SEED + 10), sklar_model, 1_000)
 
-bench_fitting!(SUITE, "gumbel_itau", GumbelCopula, gumbel_fit_data; method=:itau)
-bench_fitting!(SUITE, "gaussian_mle", GaussianCopula, gaussian_fit_data; method=:mle)
-bench_fitting!(
-    SUITE,
-    "sklar_ifm",
+SUITE["fitting"]["gumbel_itau"] = bench_fitting(GumbelCopula, gumbel_fit_data; method=:itau)
+SUITE["fitting"]["gaussian_mle"] = bench_fitting(GaussianCopula, gaussian_fit_data; method=:mle)
+SUITE["fitting"]["sklar_ifm"] = bench_fitting(
     SklarDist{ClaytonCopula,Tuple{Normal,LogNormal,Gamma}},
     sklar_fit_data;
     sklar_method=:ifm,

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -9,7 +9,10 @@ const SEED = 23
 const SUITE = BenchmarkGroup()
 
 bench_name(C) = lowercase(replace(string(nameof(typeof(C))), "Copula" => "")) * "_d$(length(C))"
-bench_group!(suite, operation) = get!(suite, operation, BenchmarkGroup())
+function bench_group!(suite, operation)
+    haskey(suite, operation) || (suite[operation] = BenchmarkGroup())
+    return suite[operation]
+end
 
 function bench_sampling!(suite, C, n)
     bench_group!(suite, "sampling")[bench_name(C)] = @benchmarkable(


### PR DESCRIPTION
Supersedes the useful workload ideas from #314 without reviving its obsolete AirspeedVelocity/Chairmarks infrastructure.

The suite now covers additional implementation paths while keeping each target attributable to one operation:

- Student and Galambos sampling;
- BB1 and Galambos density and CDF evaluation;
- Empirical CDF and Beta log-density;
- inverse Rosenblatt alongside the existing forward transform;
- bivariate condition construction, conditional CDF, and EV conditional quantile.

The family selection is representative rather than exhaustive, and all inputs/models are prepared outside the measured expressions.

Local validation: `git diff --check` passes. Loading the Julia suite could not be run on the Windows host because `julia.exe` was unavailable to the sandbox; Tachometer CI provides the intended Linux execution validation.