### PR TITLE
Reduce test wall time with type-aware CI sharding

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,7 +27,7 @@ concurrency:
 
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    name: Julia ${{ matrix.version }} - ${{ matrix.group }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -39,6 +39,14 @@ jobs:
           - ubuntu-latest
         arch:
           - x64
+        group:
+          - core
+          - generic-1
+          - generic-2
+          - generic-3
+    env:
+      COPULAS_TEST_GROUP: ${{ matrix.group }}
+      COPULAS_GENERIC_SHARDS: 3
     steps:
       - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3

--- a/test/GenericTests.jl
+++ b/test/GenericTests.jl
@@ -450,7 +450,18 @@ function _integrate_pdf_rect(rng, C::Copulas.Copula{d}, a, b, N) where d
 end
 
 # You can filter the bestiary here if you want:
-Bestiary = filter(GenericTestFilter, Bestiary)
+Bestiary = unique(filter(GenericTestFilter, Bestiary))
+
+if startswith(TEST_GROUP, "generic-")
+    shard = parse(Int, split(TEST_GROUP, '-')[2])
+    shards = parse(Int, ENV["COPULAS_GENERIC_SHARDS"])
+    1 <= shard <= shards || error("Invalid generic test shard $shard/$shards")
+    # Keep every instance of a concrete type in one process so compilation is
+    # shared across its parameter variants.
+    types = unique(typeof.(Bestiary))
+    shard_types = Set(types[shard:shards:end])
+    Bestiary = filter(C -> typeof(C) in shard_types, Bestiary)
+end
 
 @testset "Matrix sampler accepts generic buffers" begin
     C = ClaytonCopula(3, 1.0)
@@ -464,7 +475,7 @@ Bestiary = filter(GenericTestFilter, Bestiary)
 end
 
 # Launch the main computation:
-@testset for C in unique(Bestiary)
+@testset for C in Bestiary
 
     @info "Testing $C..."
     Random.seed!(rng,123)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,8 +5,9 @@ using Aqua, Copulas, DelimitedFiles, Distributions, ForwardDiff, HCubature,
 
 const rng = StableRNG(123)
 
-# You can comment the lines to avoid running some tests while you develop:
-testfiles = [
+const TEST_GROUP = get(ENV, "COPULAS_TEST_GROUP", "all")
+
+core_testfiles = [
     "Aqua",
     "ArchimedeanCopulas",
     "NestedArchimedeanCopula",
@@ -18,8 +19,12 @@ testfiles = [
     "NatafTest",
     "SklarDist",
     "Subsetting",
-    "GenericTests",
 ]
+
+testfiles = TEST_GROUP == "all" ? [core_testfiles; "GenericTests"] :
+            TEST_GROUP == "core" ? core_testfiles :
+            startswith(TEST_GROUP, "generic-") ? ["GenericTests"] :
+            error("Unknown COPULAS_TEST_GROUP: $TEST_GROUP")
 
 # You can override the definition of this GenericTestFilter if you want. 
 GenericTestFilter(C) = true # the default value lets every copula go through. 


### PR DESCRIPTION
## Goal

Reduce CI wall-clock time without removing any functional coverage from the test suite.

## Baseline

On the latest successful `main` run:

- Julia LTS tests: approximately 7m50s;
- Julia 1 tests: approximately 13m40s;
- `GenericTests.jl` alone: approximately 5m on LTS and 8m30s on Julia 1.

The per-copula timestamps show that compilation of the first instance of each concrete copula type dominates. Reducing sample counts therefore does not address the main cost.

## Experiment

- Keep ordinary local `Pkg.test()` monolithic and unchanged.
- Run specialized/core test files in one CI job per Julia version.
- Split `GenericTests.jl` into three parallel shards per Julia version.
- Assign complete concrete types, rather than individual instances, to shards so parameter variants share compilation.
- Preserve every bestiary entry and every generic test operation.

This draft exists to measure the resulting CI wall-clock time and shard balance before deciding whether the additional CI parallelism is worthwhile.