### PR TITLE
Store TCopula degrees of freedom as data

### DIFF
--- a/src/EllipticalCopula.jl
+++ b/src/EllipticalCopula.jl
@@ -47,11 +47,14 @@ References:
 * [nelsen2006](@cite) Nelsen, Roger B. An introduction to copulas. Springer, 2006.
 """
 abstract type EllipticalCopula{d,MT} <: Copula{d} end
-Base.eltype(C::CT) where CT<:EllipticalCopula = Base.eltype(N(CT)(C.Σ))
+U(C::CT) where {CT<:EllipticalCopula} = U(CT)
+N(C::CT) where {CT<:EllipticalCopula} = N(CT)
+
+Base.eltype(C::EllipticalCopula) = Base.eltype(N(C)(C.Σ))
 function Distributions._rand!(rng::Distributions.AbstractRNG, C::CT, A::AbstractMatrix{T}) where {T<:Real, CT<:EllipticalCopula}
     # More efficient version that precomputes stuff:
-    n = N(CT)(C.Σ)
-    u = U(CT)
+    n = N(C)(C.Σ)
+    u = U(C)
     Random.rand!(rng,n,A)
     @inbounds for j in axes(A, 2), i in axes(A, 1)
         A[i, j] = clamp(T(Distributions.cdf(u, A[i, j])), zero(T), one(T))
@@ -64,7 +67,7 @@ function Distributions._logpdf(C::CT, u) where {CT <: EllipticalCopula}
     TΣ = eltype(C.Σ)
     Tu = eltype(u)
     T = promote_type(TΣ, Tu)
-    U₁ = U(CT)
+    U₁ = U(C)
     # quantiles
     x = Vector{T}(undef, d)
     @inbounds for i in 1:d
@@ -75,7 +78,7 @@ function Distributions._logpdf(C::CT, u) where {CT <: EllipticalCopula}
     @inbounds for i in 1:d
         s += Distributions.logpdf(U₁, x[i])
     end
-    return Distributions.logpdf(N(CT)(C.Σ),x) - s
+    return Distributions.logpdf(N(C)(C.Σ),x) - s
 end
 function make_cor!(Σ)
     # Verify that Σ is a correlation matrix, otherwise make it so : 

--- a/src/EllipticalCopulas/TCopula.jl
+++ b/src/EllipticalCopulas/TCopula.jl
@@ -1,8 +1,8 @@
 """
-    TCopula{d, df, MT}
+    TCopula{d, Tν, MT}
 
 Fields:
-- `df::Int` — degrees of freedom
+- `df::Tν` — degrees of freedom
 - `Σ::MT` — correlation matrix
 
 Constructor
@@ -28,22 +28,23 @@ pdf(C, u); cdf(C, u)
 References:
 * [nelsen2006](@cite) Nelsen, Roger B. An introduction to copulas. Springer, 2006.
 """
-struct TCopula{d,df,MT} <: EllipticalCopula{d,MT}
+struct TCopula{d,Tν,MT} <: EllipticalCopula{d,MT}
+    df::Tν
     Σ::MT
-    function TCopula(df,Σ)
+    function TCopula(df::Real, Σ::AbstractMatrix)
         make_cor!(Σ)
-        N(TCopula{size(Σ,1),df,typeof(Σ)})(Σ)
-        return new{size(Σ,1),df,typeof(Σ)}(Σ)
+        Distributions.MvTDist(df, Σ)
+        return new{size(Σ,1),typeof(df),typeof(Σ)}(df, Σ)
     end
 end
 TCopula(d::Int, ν::Real, Σ::AbstractMatrix) = TCopula(ν, Σ)
-TCopula{D,df,MT}(d::Int, ν::Real, Σ::AbstractMatrix)  where {D,df,MT} = TCopula(ν, Σ)
+TCopula{D,Tν,MT}(d::Int, ν::Real, Σ::AbstractMatrix) where {D,Tν,MT} = TCopula(ν, Σ)
 
 
 
-U(::Type{TCopula{d,df,MT}}) where {d,df,MT} = Distributions.TDist(df)
-N(::Type{TCopula{d,df,MT}}) where {d,df,MT} = function(Σ)
-    Distributions.MvTDist(df,Σ)
+U(C::TCopula) = Distributions.TDist(C.df)
+N(C::TCopula) = function(Σ)
+    Distributions.MvTDist(C.df, Σ)
 end
 
 function _student_rosenblatt_cache(C::TCopula{d}) where d
@@ -58,8 +59,9 @@ function _student_rosenblatt_cache(C::TCopula{d}) where d
     end
 end
 
-function rosenblatt(C::TCopula{d,ν}, u::AbstractMatrix{<:Real}) where {d,ν}
+function rosenblatt(C::TCopula{d}, u::AbstractMatrix{<:Real}) where {d}
     size(u, 1) == d || throw(ArgumentError("Dimension mismatch between copula and input matrix"))
+    ν = C.df
     Tu = Distributions.TDist(ν)
     z = Distributions.quantile.(Tu, u)
     v = similar(z)
@@ -80,8 +82,9 @@ function rosenblatt(C::TCopula{d,ν}, u::AbstractMatrix{<:Real}) where {d,ν}
     return v
 end
 
-function inverse_rosenblatt(C::TCopula{d,ν}, s::AbstractMatrix{<:Real}) where {d,ν}
+function inverse_rosenblatt(C::TCopula{d}, s::AbstractMatrix{<:Real}) where {d}
     size(s, 1) == d || throw(ArgumentError("Dimension mismatch between copula and input matrix"))
+    ν = C.df
     Tu = Distributions.TDist(ν)
     z = similar(s, float(promote_type(eltype(s), eltype(C.Σ))))
     v = similar(z)
@@ -106,10 +109,11 @@ end
 
 # Kendall tau of bivariate student:
 # Lindskog, F., McNeil, A., & Schmock, U. (2003). Kendall’s tau for elliptical distributions. In Credit risk: Measurement, evaluation and management (pp. 149-156). Heidelberg: Physica-Verlag HD.
-τ(C::TCopula{2,MT}) where MT = 2*asin(C.Σ[1,2])/π 
+τ(C::TCopula{2}) = 2*asin(C.Σ[1,2])/π
 
 # Conditioning colocated
-function DistortionFromCop(C::TCopula{D,ν,MT}, js::NTuple{p,Int}, uⱼₛ::NTuple{p,Float64}, i::Int) where {p,D,ν,MT}
+function DistortionFromCop(C::TCopula{D}, js::NTuple{p,Int}, uⱼₛ::NTuple{p,Float64}, i::Int) where {p,D}
+    ν = C.df
     Σ = C.Σ; jst = js; ist = Tuple(setdiff(1:D, jst)); @assert i in ist
     Jv = collect(jst); zJ = Distributions.quantile.(Distributions.TDist(ν), collect(uⱼₛ))
     ΣJJ = Σ[Jv, Jv]; RiJ = Σ[i, Jv]; RJi = Σ[Jv, i]
@@ -125,7 +129,8 @@ function DistortionFromCop(C::TCopula{D,ν,MT}, js::NTuple{p,Int}, uⱼₛ::NTup
     νp = ν + length(Jv); σz = sqrt(max(σ0², zero(σ0²))) * sqrt((ν + δ) / νp)
     return StudentDistortion(float(μz), float(σz), Int(ν), Int(νp))
 end
-function ConditionalCopula(C::TCopula{D,df,MT}, js, uⱼₛ) where {D,df,MT}
+function ConditionalCopula(C::TCopula{D}, js, uⱼₛ) where {D}
+    df = C.df
     p = length(js); J = collect(Int, js); I = collect(setdiff(1:D, J)); Σ = C.Σ
     if p == 1
         Σcond = Σ[I, I] - Σ[I, J] * (Σ[J, J] \ Σ[J, I])
@@ -138,8 +143,9 @@ function ConditionalCopula(C::TCopula{D,df,MT}, js, uⱼₛ) where {D,df,MT}
     return TCopula(df + p, R_cond)
 end
 
-function _conditional_components(C::TCopula{D,ν,MT}, js::NTuple{p,Int},
-                                 uⱼₛ::NTuple{p,Float64}, is) where {D,ν,MT,p}
+function _conditional_components(C::TCopula{D}, js::NTuple{p,Int},
+                                 uⱼₛ::NTuple{p,Float64}, is) where {D,p}
+    ν = C.df
     J = collect(Int, js)
     I = collect(Int, is)
     Σ = C.Σ
@@ -161,13 +167,11 @@ function _conditional_components(C::TCopula{D,ν,MT}, js::NTuple{p,Int},
     return TCopula(νp, Rcond), distortions
 end
 # Subsetting colocated
-SubsetCopula(C::TCopula{d,df,MT}, dims::NTuple{p, Int}) where {d,df,MT,p} = TCopula(df, C.Σ[collect(dims),collect(dims)])
+SubsetCopula(C::TCopula, dims::NTuple{p, Int}) where {p} = TCopula(C.df, C.Σ[collect(dims),collect(dims)])
 
 # Fitting collocated
 StatsBase.dof(C::Copulas.TCopula)           = (p = length(C); p*(p-1) ÷ 2 + 1)
-function Distributions.params(C::TCopula{d,df,MT}) where {d,df,MT}
-    return (; ν = df, Σ = C.Σ)
-end
+Distributions.params(C::TCopula) = (; ν = C.df, Σ = C.Σ)
 _example(::Type{<:TCopula}, d::Int) = TCopula(5.0, Matrix(LinearAlgebra.I, d, d) .+ 0.2 .* (ones(d, d) .- Matrix(LinearAlgebra.I, d, d)))
 function _unbound_params(::Type{<:TCopula}, d::Int, θ::NamedTuple)
     α = _unbound_corr_params(d, θ.Σ)

--- a/test/EllipticalCopulas.jl
+++ b/test/EllipticalCopulas.jl
@@ -10,6 +10,18 @@
     @test true
 end
 
+@testset "TCopula degrees of freedom are data, not a type value" begin
+    Σ = [1.0 0.25; 0.25 1.0]
+    C2 = TCopula(2, copy(Σ))
+    C20 = TCopula(20, copy(Σ))
+
+    @test typeof(C2) === typeof(C20)
+    @test params(C2).ν == 2
+    @test params(C20).ν == 20
+    @test Copulas.U(C2) == TDist(2)
+    @test Copulas.U(C20) == TDist(20)
+end
+
 @testset "Fix value Gaussian Copula & SklarDist" begin
     # [GenericTests integration]: Yes. This is a regression value test for cdf(SklarDist(...)); can be moved to a generic Sklar fixture tests.
 


### PR DESCRIPTION
## Summary

- store the Student degrees of freedom as a field instead of a value type parameter
- let the generic elliptical implementation obtain its distributions from an instance when needed
- verify that different degrees of freedom with the same numeric and matrix types now share one concrete TCopula type

## Motivation

The degrees of freedom affect numerical values, but do not select a distinct implementation. Encoding each value in the type caused separate compilation for otherwise identical code paths (for example, nu = 2 and nu = 20). The numeric type remains represented by Tnu, preserving specialization across Float32, Float64, BigFloat, and other numeric types.

## Validation

Static review and git diff checks only. The local Julia executable is unavailable in this environment, and the full suite is intentionally left to CI because it is long-running.