### PR TITLE
Collect CI coverage on Julia LTS only

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -50,8 +50,11 @@ jobs:
       - uses: julia-actions/julia-runtest@v1
         with:
           force_latest_compatible_version: ${{ matrix.version == 'lts' && 'false' || 'auto' }}
+          coverage: ${{ matrix.version == 'lts' }}
       - uses: julia-actions/julia-processcoverage@v1
+        if: matrix.version == 'lts'
       - uses: codecov/codecov-action@v7
+        if: matrix.version == 'lts'
         with:
           files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Julia 1 currently resolves to Julia 1.12, whose coverage instrumentation has a known performance regression (JuliaLang/julia#62424). Across recent Copulas.jl runs, the Julia 1 test job takes about 1.5x as long as LTS, with nearly all of the difference inside the instrumented test step.

This keeps the full test matrix unchanged, but collects and uploads coverage only from the LTS job. The Julia 1 job still runs the same tests and remains the compatibility check for the latest stable Julia release.

Expected result: faster Julia 1 feedback without reducing functional coverage or Codecov source coverage.