### PR TITLE
Avoid factorial overflow in high dimensions

### DIFF
--- a/src/Copula.jl
+++ b/src/Copula.jl
@@ -64,7 +64,7 @@ end
 function γ(C::Copula{d}) where {d}
     _integrand(u) = (1 + minimum(u) - maximum(u) + max(abs(sum(u) - d/2) - (d - 2)/2, 0.0)) / 2
     I = Distributions.expectation(_integrand, C; nsamples=10^4)
-    a = 1/(d+1) + 1/factorial(d+1)   # independence
+    a = 1/(d+1) + _div_factorial(one(float(I)), d+1)   # independence
     b = (2 + 4.0^(1-d)) / 3          # comonotonicity
     return (I - a) / (b - a)
 end
@@ -116,7 +116,7 @@ function γ(U::AbstractMatrix)
         I += (1 + minimum(u) - maximum(u) + max(abs(sum(u) - d/2) - (d - 2)/2, 0.0)) / 2
     end
     I /= n
-    a = 1/(d+1) + 1/factorial(d+1)
+    a = 1/(d+1) + _div_factorial(one(float(I)), d+1)
     b = (2 + 4.0^(1-d)) / 3
     return (I - a) / (b - a)
 end

--- a/src/Generator.jl
+++ b/src/Generator.jl
@@ -44,7 +44,10 @@ max_monotony(G::Generator) = throw("This generator does not have a defined max m
 ϕ⁻¹( G::Generator, x) = Roots.find_zero(t -> ϕ(G,t) - x, (0.0, Inf))
 ϕ⁽¹⁾(G::Generator, t) = ForwardDiff.derivative(x -> ϕ(G,x), t)
 ϕ⁻¹⁽¹⁾(G::Generator, t) = ForwardDiff.derivative(x -> ϕ⁻¹(G, x), t)
-ϕ⁽ᵏ⁾(G::Generator, k::Int, t) = taylor(ϕ(G), t, k)[end] * factorial(k)
+function ϕ⁽ᵏ⁾(G::Generator, k::Int, t)
+    k ≥ 0 || throw(ArgumentError("k must be non-negative"))
+    return _mul_factorial(taylor(ϕ(G), t, k)[end], k)
+end
 function ϕ⁽ᵏ⁾⁻¹(G::Generator, k::Int, t; start_at=t)
     f(x) = ϕ⁽ᵏ⁾(G, k, x) - t
     T = typeof(float(t))
@@ -123,17 +126,17 @@ struct 𝒲₋₁{TG, TO<:Integer} <: Distributions.ContinuousUnivariateDistribu
 end
 function Distributions.cdf(dist::𝒲₋₁, x::Real)
     x ≤ 0 && return zero(x)
-    rez, x_pow = zero(x), one(x)
+    rez, scaled_power = zero(x), one(x)
     @inbounds for k in 1:dist.order
         cₖ = if k == 1
             ϕ(dist.G, x)
         elseif k == 2
             ϕ⁽¹⁾(dist.G, x)
         else
-            ϕ⁽ᵏ⁾(dist.G, k-1, x) / Base.factorial(k-1)
+            ϕ⁽ᵏ⁾(dist.G, k-1, x)
         end
-        rez += x_pow * cₖ
-        x_pow *= -x
+        rez += scaled_power * cₖ
+        scaled_power *= -x / k
     end
     F = 1 - rez
     # Guard against tiny numerical excursions

--- a/src/Generator/JoeGenerator.jl
+++ b/src/Generator/JoeGenerator.jl
@@ -56,7 +56,7 @@ function ϕ⁽ᵏ⁾(G::JoeGenerator, d::Int, t)
     x = exp(-t)
     y = -expm1(-t)
     r = x/y
-    P_d_α = sum(Combinatorics.stirlings2(d, k) * (SpecialFunctions.gamma(k - α) / SpecialFunctions.gamma(1 - α)) * r^(k-1) for k in 1:d)
+    P_d_α = sum(Combinatorics.stirlings2(d, k) * _rising_factorial(1 - α, k - 1) * r^(k-1) for k in 1:d)
     return (-1)^d * α * (x / y^(1 - α)) * P_d_α
 end
 function ϕ⁻¹⁽¹⁾(G::JoeGenerator, t)

--- a/src/MiscellaneousCopulas/RafteryCopula.jl
+++ b/src/MiscellaneousCopulas/RafteryCopula.jl
@@ -83,9 +83,13 @@ function Distributions._rand!(rng::Distributions.AbstractRNG, R::RafteryCopula{d
     return A
 end
 function ρ(R::RafteryCopula{d,P}) where {d, P}
-    term1 = (d+1)*(2^d-(2-R.θ)^d)-(2^d*R.θ*d)
-    term2 = (2-R.θ)^d*(2^d-d-1) 
-    return term1/term2
+    T = typeof(float(R.θ))
+    θ = T(R.θ)
+    inv2d = exp2(-T(d))
+    scaled_power = (one(T) - θ / 2)^d
+    numerator = T(d + 1) * (one(T) - scaled_power) - θ * d
+    denominator = scaled_power * (one(T) - T(d + 1) * inv2d)
+    return numerator * inv2d / denominator
 end
 function τ(R::RafteryCopula{d, P}) where {d, P}
     T = typeof(float(R.θ))

--- a/src/MiscellaneousCopulas/RafteryCopula.jl
+++ b/src/MiscellaneousCopulas/RafteryCopula.jl
@@ -88,15 +88,23 @@ function ρ(R::RafteryCopula{d,P}) where {d, P}
     return term1/term2
 end
 function τ(R::RafteryCopula{d, P}) where {d, P}
-    term1 = (2^(d-1) * factorial(d)) / ((2^(d-1)-1) * prod(i+1-R.θ for i in 2:d))
-    term2 = ((1 - R.θ)^2 * (d^2 - 1)) / ((d-1+R.θ) * (d+1-R.θ) * (2^(d-1)-1))
-    term3_sum = 0.0
-    for k in 2:d
-        term3_sum += (R.θ * (1-R.θ) * (2-R.θ)) / (2^k * factorial(k-1) * (1-R.θ-k) * (2-R.θ-k) * prod(i+1-R.θ for i in k:d))
+    T = typeof(float(R.θ))
+    θ = T(R.θ)
+    pow2 = exp2(T(1 - d))
+    normalization = inv(one(T) - pow2)
+    common = θ * (one(T) - θ) * (T(2) - θ)
+
+    ratio = one(T)
+    term3 = zero(T)
+    for k in d:-1:2
+        ratio *= T(k) / (T(k + 1) - θ)
+        term3 += common * exp2(T(1 - k)) * normalization * ratio /
+                 ((one(T) - θ - k) * (T(2) - θ - k))
     end
-    term3 = (2^d * factorial(d)) / (2^(d-1)-1) * term3_sum
-    
-    term4 = 1 / (2^(d-1)-1)
-    
+
+    term1 = normalization * ratio
+    term2 = (one(T) - θ)^2 * (T(d)^2 - one(T)) * pow2 * normalization /
+            ((T(d - 1) + θ) * (T(d + 1) - θ))
+    term4 = pow2 * normalization
     return term1 + term2 - term3 - term4
 end

--- a/src/NestedArchimedeanCopula.jl
+++ b/src/NestedArchimedeanCopula.jl
@@ -119,9 +119,9 @@ function composition_taylor_implicit(outer::Generator, inner::Generator, t₀::T
     # triangular qₖ=(bₖ − Σ_{m≥2} aₘ[εᵏ]Qᵐ)/a₁ below — no Taylor1 on ϕ/ϕ⁻¹.
     # Derivative-side coefficients: a[m] = ϕ⁽ᵐ⁾(outer,h₀)/m!, b[m] = ϕ⁽ᵐ⁾(inner,t₀)/m!
     # for m = 1..d (scalar k-th derivatives — NO Taylor1 on ϕ/ϕ⁻¹).
-    b  = T[ϕ⁽ᵏ⁾(inner, m, t₀) / T(factorial(big(m))) for m in 1:d]
+    b  = T[_div_factorial(ϕ⁽ᵏ⁾(inner, m, t₀), m) for m in 1:d]
     h₀ = ϕ⁻¹(outer, ϕ(inner, t₀))                      # single scalar inverse
-    a  = T[ϕ⁽ᵏ⁾(outer, m, h₀) / T(factorial(big(m))) for m in 1:d]
+    a  = T[_div_factorial(ϕ⁽ᵏ⁾(outer, m, h₀), m) for m in 1:d]
 
     q = zeros(T, d)
     q[1] = b[1] / a[1]
@@ -173,8 +173,12 @@ function _faa_di_bruno_coeffs(p::AbstractVector{T}, β::AbstractVector{T}, d::In
     n = d + 1
     p_pad = zeros(T, n)
     p_pad[2:min(n, length(p) + 1)] .= p[1:min(d, length(p))]
-    facts = T[factorial(big(j)) for j in 0:d]
-    invf  = T[1 / factorial(big(j)) for j in 0:d]
+    facts = ones(T, d + 1)
+    invf = ones(T, d + 1)
+    @inbounds for j in 1:d
+        facts[j + 1] = facts[j] * j
+        invf[j + 1] = invf[j] / j
+    end
     β_scaled = T[β[j] * facts[j] for j in 1:n]
     α = zeros(T, n)
     q1 = copy(p_pad)

--- a/src/UnivariateDistribution/Radials/ClaytonWilliamsonDistribution.jl
+++ b/src/UnivariateDistribution/Radials/ClaytonWilliamsonDistribution.jl
@@ -13,17 +13,25 @@ struct ClaytonWilliamsonDistribution{T<:Real} <: Distributions.ContinuousUnivari
 end
 Base.minimum(D::ClaytonWilliamsonDistribution) = zero(D.θ)
 Base.maximum(D::ClaytonWilliamsonDistribution) = -1/D.θ
-@inline _clayton_choose(a, b) = SpecialFunctions.gamma(a + 1) / (SpecialFunctions.gamma(b + 1) * SpecialFunctions.gamma(a - b + 1))
+@inline function _clayton_logchoose(a, k::Integer)
+    k ≥ 0 || throw(ArgumentError("k must be non-negative"))
+    result = zero(float(a))
+    @inbounds for j in 0:(k - 1)
+        result += log(a - j) - log(j + 1)
+    end
+    return result
+end
 function Distributions.cdf(D::ClaytonWilliamsonDistribution, x::Real)
     θ = D.θ
     d = D.d
-    x < 0 && return zero(x)
+    x <= 0 && return zero(x)
     α = -1/θ
     x >= α && return one(x)
     rez = zero(x)
     y = x/α
     for k in 0:(d-1)
-        rez += _clayton_choose(α, α-k) * y^k * (1 - y)^(α-k)
+        logterm = _clayton_logchoose(α, k) + k*log(y) + (α-k)*log1p(-y)
+        rez += exp(logterm)
     end
     return 1-rez
 end
@@ -32,16 +40,12 @@ function Distributions.rand(rng::Distributions.AbstractRNG, d::ClaytonWilliamson
     Roots.find_zero(x -> (Distributions.cdf(d,x) - u), (0.0, Inf))
 end
 function Distributions.pdf(D::ClaytonWilliamsonDistribution, x::Real)
-    d = D.d
-    α = -1/D.θ
-    (0 ≥ x || x ≥ α) && return zero(x)
-    y = x/α
-    return _clayton_choose(α - 1, d - 1) * y^(d-1) * (1 - y)^(α - d)
+    return exp(Distributions.logpdf(D, x))
 end
 function Distributions.logpdf(D::ClaytonWilliamsonDistribution, x::Real)
     d = D.d
     α = -1/D.θ
     (0 ≥ x || x ≥ α) && return -Inf
     y = x/α
-    return log(_clayton_choose(α - 1, d - 1)) + (d-1)*log(y) + (α - d)*log1p(-y)
+    return _clayton_logchoose(α - 1, d - 1) + (d-1)*log(y) + (α - d)*log1p(-y)
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -27,6 +27,34 @@ function _falling_factorial(x, k::Integer)
     return result
 end
 
+"""Multiply `x` by `k!` without first forming an integer factorial."""
+function _mul_factorial(x, k::Integer)
+    k ≥ 0 || throw(ArgumentError("k must be non-negative"))
+    @inbounds for j in 2:k
+        x *= j
+    end
+    return x
+end
+
+"""Divide `x` by `k!` without first forming an integer factorial."""
+function _div_factorial(x, k::Integer)
+    k ≥ 0 || throw(ArgumentError("k must be non-negative"))
+    @inbounds for j in 2:k
+        x /= j
+    end
+    return x
+end
+
+"""Compute `x * (x + 1) * ⋯ * (x + k - 1)` directly."""
+function _rising_factorial(x, k::Integer)
+    k ≥ 0 || throw(ArgumentError("k must be non-negative"))
+    result = one(x)
+    @inbounds for j in 0:(k - 1)
+        result *= x + j
+    end
+    return result
+end
+
 """
     taylor(f::F, x₀, d::Int) where {F}
 

--- a/test/ArchimedeanCopulas.jl
+++ b/test/ArchimedeanCopulas.jl
@@ -52,6 +52,32 @@
     @test size(rand(rng, C, 3)) == (2, 3)
 end
 
+@testset "Stable factorial recurrences" begin
+    @test Copulas._mul_factorial(1.0, 22) ≈ gamma(23)
+    @test Copulas._div_factorial(1.0, 22) ≈ inv(gamma(23))
+    @test Copulas._rising_factorial(0.5, 9) ≈ gamma(9.5) / gamma(0.5)
+
+    G = Copulas.ClaytonGenerator(1.0)
+    generic_derivative = invoke(
+        Copulas.ϕ⁽ᵏ⁾,
+        Tuple{Copulas.Generator, Int, Any},
+        G,
+        22,
+        1.0,
+    )
+    @test generic_derivative ≈ Copulas.ϕ⁽ᵏ⁾(G, 22, 1.0)
+
+    radial = Copulas.𝒲₋₁(G, 22)
+    @test 0 <= cdf(radial, 1.0) <= 1
+
+    clayton_radial = Copulas.ClaytonWilliamsonDistribution(-0.001, 25)
+    @test cdf(clayton_radial, 0.0) == 0
+    @test 0 <= cdf(clayton_radial, 500.0) <= 1
+    @test isfinite(logpdf(clayton_radial, 500.0))
+
+    @test isfinite(Copulas.γ(rand(rng, 25, 10)))
+end
+
 
 @testset "Boundary test for bivariate Joe, Gumbel and Frank" begin
     # [GenericTests integration]: Yes, valuable. A general "pdf zero on boundaries when defined" property exists for families with known boundary behavior.

--- a/test/MiscelaneousCopulas.jl
+++ b/test/MiscelaneousCopulas.jl
@@ -92,6 +92,9 @@ end
     @test Copulas.τ(RafteryCopula{3}(0.5)) ≈ 0.4
     @test Copulas.τ(RafteryCopula{10}(0.8)) ≈ 0.6307638245383256
     @test Copulas.τ(RafteryCopula{25}(0.5)) ≈ 0.18523466942807426
+    @test Copulas.ρ(RafteryCopula{2}(0.2)) ≈ 0.2098765432098763
+    @test Copulas.ρ(RafteryCopula{3}(0.5)) ≈ 0.48148148148148145
+    @test isfinite(Copulas.ρ(RafteryCopula{100}(0.5)))
 end
 
 @testset "Check against manual version - CDF" begin

--- a/test/MiscelaneousCopulas.jl
+++ b/test/MiscelaneousCopulas.jl
@@ -87,6 +87,11 @@ end
     @test pdf(RafteryCopula{2}(0.5), [0.3, 0.8]) ≈ 0.6325 atol=1e-4
     @test pdf(RafteryCopula{3}(0.5), [0.1, 0.2, 0.3]) ≈ 1.9945086 atol=1e-4
     @test pdf(RafteryCopula{3}(0.1), [0.4, 0.8, 0.2]) ≈ 0.939229 atol=1e-4
+
+    @test Copulas.τ(RafteryCopula{2}(0.2)) ≈ 1/7
+    @test Copulas.τ(RafteryCopula{3}(0.5)) ≈ 0.4
+    @test Copulas.τ(RafteryCopula{10}(0.8)) ≈ 0.6307638245383256
+    @test Copulas.τ(RafteryCopula{25}(0.5)) ≈ 0.18523466942807426
 end
 
 @testset "Check against manual version - CDF" begin


### PR DESCRIPTION
Fixes #362.

This replaces integer and `BigInt` factorial intermediates with typed recurrences in the high-dimensional numerical paths:

- generic Archimedean generator derivatives and inverse Williamson CDFs;
- nested Archimedean composition and Faà di Bruno coefficients;
- multivariate gamma normalization;
- Raftery's Kendall tau, using ratios after algebraic cancellation;
- Clayton radial generalized binomials, evaluated in the log domain;
- Joe's gamma ratio, expressed as a rising factorial.

The change avoids the `Int` overflow above dimension 20 without paying the cost of `factorial(big(d))`. Regression coverage exercises dimensions 22–25 and preserves the existing low-dimensional values.

Targeted local validation:

- `test/ArchimedeanCopulas.jl`
- `test/MiscelaneousCopulas.jl`
- `test/NestedArchimedeanCopula.jl` (150/150 passing)

The full suite is left to CI.
