### PR TITLE
Add automatic copula family selection

### DIFF
--- a/docs/src/manual/fitting_interface.md
+++ b/docs/src/manual/fitting_interface.md
@@ -45,6 +45,59 @@ Returns a [`CopulaModel`](@ref) with:
 - `vcov` (if available),
 - `method_details` (a `NamedTuple` with method-specific metadata).
 
+## Automatic copula-family selection
+
+When the copula family is unknown, `CopulaModel` can select it automatically
+from a collection of candidate families:
+
+```@example fitting_interface
+Ctrue = ClaytonCopula(2, 4.0)
+Usel = rand(Ctrue, 1_000)
+
+Msel = fit(
+    CopulaModel,
+    Copula,
+    Usel;
+    candidates=(ClaytonCopula, GumbelCopula, FrankCopula),
+    criterion=:bic,
+    vcov=false,
+)
+Msel
+```
+
+The available information criteria are:
+
+- `:bic` — Bayesian information criterion,
+- `:aic` — Akaike information criterion,
+- `:aicc` — finite-sample corrected AIC,
+- `:hqc` — Hannan–Quinn criterion.
+
+With `criterion=:default`, BIC is used.
+
+Candidate fits are compared using the requested criterion, and the family with
+the smallest eligible finite value is selected. The winning family is then
+fitted once more using the inference options requested by the user.
+
+The complete comparison can be inspected with [`selectiontable`](@ref):
+
+```@example fitting_interface
+selectiontable(Msel)
+```
+
+Each row stores the candidate family, fitting status and method,
+log-likelihood, number of parameters, and all four information criteria.
+Candidates that fail to fit can be skipped with `on_error=:skip` (the default)
+or propagated immediately with `on_error=:throw`.
+
+Two built-in candidate collections are available:
+
+- `candidates=:default` uses a conservative set of commonly used parametric families;
+- `candidates=:all` considers the broader built-in parametric repertoire compatible with the data dimension.
+
+An explicit tuple of families is recommended when the scientific problem
+already restricts the plausible candidate set.
+
+
 ---
 
 ## Behavior & conventions (important)

--- a/docs/src/manual/fitting_interface.md
+++ b/docs/src/manual/fitting_interface.md
@@ -72,11 +72,11 @@ The available information criteria are:
 - `:aicc` — finite-sample corrected AIC,
 - `:hqc` — Hannan–Quinn criterion.
 
-With `criterion=:default`, BIC is used.
+BIC is the default criterion.
 
 Candidate fits are compared using the requested criterion, and the family with
-the smallest eligible finite value is selected. The winning family is then
-fitted once more using the inference options requested by the user.
+the smallest eligible finite value is selected. The winning fit is reused:
+only its requested inference (such as covariance estimation) is computed afterwards.
 
 The complete comparison can be inspected with [`selectiontable`](@ref):
 
@@ -89,13 +89,19 @@ log-likelihood, number of parameters, and all four information criteria.
 Candidates that fail to fit can be skipped with `on_error=:skip` (the default)
 or propagated immediately with `on_error=:throw`.
 
-Two built-in candidate collections are available:
+The candidate collection is required and explicit; choose families appropriate
+for the scientific problem and the data dimension. `selectiontable` returns a
+plain vector of comparison rows. Nonfinite scores and, by default, nonconverged
+fits are excluded. Interruptions always propagate, even with `on_error=:skip`.
 
-- `candidates=:default` uses a conservative set of commonly used parametric families;
-- `candidates=:all` considers the broader built-in parametric repertoire compatible with the data dimension.
+Use maximum-likelihood fitting for the usual information-criterion interpretation;
+passing another fitting method merely compares the scores at those estimates.
+The shorter `fit(Copula, U; candidates=(...))` returns only the selected copula.
 
-An explicit tuple of families is recommended when the scientific problem
-already restricts the plausible candidate set.
+`GOFCopulaTest(Msel)` and `GOFCopulaTest(Msel, U)` are deliberately unsupported:
+a valid selection-aware bootstrap must repeat family selection in every replicate,
+not just refit the winning family. These calls throw rather than silently omit
+the selection step.
 
 
 ---

--- a/docs/src/manual/fitting_interface.md
+++ b/docs/src/manual/fitting_interface.md
@@ -56,7 +56,7 @@ Usel = rand(Ctrue, 1_000)
 
 Msel = fit(
     CopulaModel,
-    Copula,
+    Copulas.Copula,
     Usel;
     candidates=(ClaytonCopula, GumbelCopula, FrankCopula),
     criterion=:bic,
@@ -96,7 +96,7 @@ fits are excluded. Interruptions always propagate, even with `on_error=:skip`.
 
 Use maximum-likelihood fitting for the usual information-criterion interpretation;
 passing another fitting method merely compares the scores at those estimates.
-The shorter `fit(Copula, U; candidates=(...))` returns only the selected copula.
+The shorter `fit(Copulas.Copula, U; candidates=(...))` returns only the selected copula.
 
 `GOFCopulaTest(Msel)` and `GOFCopulaTest(Msel, U)` are deliberately unsupported:
 a valid selection-aware bootstrap must repeat family selection in every replicate,

--- a/src/Copulas.jl
+++ b/src/Copulas.jl
@@ -142,7 +142,7 @@ module Copulas
     include("show.jl")
 
     export pseudos, condition, subsetdims, rosenblatt, inverse_rosenblatt, Nataf
-    export SklarDist, CopulaModel
+    export SklarDist, CopulaModel, selectiontable
     export CopulaTest
     export IndependenceCopulaTest, ExchangeabilityCopulaTest
     export RadialSymmetryCopulaTest, ExtremeValueCopulaTest, GOFCopulaTest

--- a/src/Fitting.jl
+++ b/src/Fitting.jl
@@ -254,6 +254,15 @@ function Distributions.fit(::Type{CopulaModel}, CT::Type{<:Copula}, U;
     quick_fit && return (result=C,) # as soon as possible.
     ll = Distributions.loglikelihood(C, U)
 
+    return _finish_copula_fit(CT, C, U, ll, method, meta, t, fit_spec;
+        derived_measures, vcov, vcov_method)
+end
+
+# Assemble inference around an existing fit, without rerunning its estimator.
+function _finish_copula_fit(CT, C, U, ll, method, meta, t, fit_spec;
+        derived_measures=true, vcov=true, vcov_method=nothing)
+    d, n = size(U)
+
     if vcov && C isa TCopula
         vcov = false
         @info "Setting vcov = false for TCopula since _beta_inc_inv derivative are not implemented"
@@ -711,218 +720,87 @@ end
 ###############################################################################
 
 """
-    _available_selection_criteria()
-
-Return the information criteria available for automatic copula selection.
-The first entry is used when `criterion=:default`.
-"""
-_available_selection_criteria() = (:bic, :aic, :aicc, :hqc)
-
-struct CopulaSelectionTable{T,R<:AbstractVector{T}} <: AbstractVector{T}
-    rows::R
-    criterion::Symbol
-    selected_family
-end
-
-Base.IndexStyle(::Type{<:CopulaSelectionTable}) = IndexLinear()
-Base.size(table::CopulaSelectionTable) = size(table.rows)
-Base.getindex(table::CopulaSelectionTable, i::Int) = table.rows[i]
-Base.sort(table::CopulaSelectionTable; kwargs...) =
-    CopulaSelectionTable(sort(table.rows; kwargs...), table.criterion, table.selected_family)
-
-"""
-    _default_copula_candidates(d)
-
-Return the built-in parametric copula families considered by automatic
-selection in dimension `d` when `candidates=:default`.
-"""
-function _default_copula_candidates(d::Integer)
-    common = (
-        GaussianCopula,
-        TCopula,
-        AMHCopula,
-        ClaytonCopula,
-        FrankCopula,
-        GumbelCopula,
-        JoeCopula,
-        GalambosCopula,
-        HuslerReissCopula,
-        LogCopula,
-    )
-    d == 2 && return (common..., PlackettCopula)
-    return common
-end
-
-"""
-    _all_copula_candidates(d)
-
-Return the broad built-in parametric copula repertoire considered by automatic
-selection when `candidates=:all`.
-"""
-function _all_copula_candidates(d::Integer)
-    common = (
-        IndependentCopula,
-        GaussianCopula,
-        TCopula,
-        AMHCopula,
-        ClaytonCopula,
-        FrankCopula,
-        GumbelCopula,
-        GumbelBarnettCopula,
-        InvGaussianCopula,
-        JoeCopula,
-        BB1Copula,
-        BB2Copula,
-        BB3Copula,
-        BB6Copula,
-        BB7Copula,
-        BB8Copula,
-        BB9Copula,
-        BB10Copula,
-        RafteryCopula,
-        GalambosCopula,
-        HuslerReissCopula,
-        LogCopula,
-        CuadrasAugeCopula,
-        MixedCopula,
-        MOCopula,
-        TawnCopula,
-    )
-    d == 2 && return (
-        common...,
-        PlackettCopula,
-        FGMCopula,
-        BB4Copula,
-        BB5Copula,
-        AsymGalambosCopula,
-        AsymLogCopula,
-        AsymMixedCopula,
-        BC2Copula,
-    )
-    return common
-end
-
-function _selection_candidates(candidates, d::Integer)
-    candidates === :default && return _default_copula_candidates(d)
-    candidates === :all && return _all_copula_candidates(d)
-    return (candidates isa Type || candidates isa UnionAll) ? (candidates,) : Tuple(candidates)
-end
-
-"""
     selectiontable(model::CopulaModel)
 
-Return the candidate-comparison table stored in an automatically selected
-copula model.
+Return the vector of candidate comparison rows from automatic family selection.
 """
 function selectiontable(M::CopulaModel)
-    get(M.method_details, :selection, false) ||
+    haskey(M.method_details, :selection_table) ||
         throw(ArgumentError("The model was not produced by automatic copula selection."))
-    return CopulaSelectionTable(
-        M.method_details.selection_table,
-        M.method_details.criterion,
-        M.method_details.selected_family,
-    )
+    return M.method_details.selection_table
 end
 
 """
-    fit(CopulaModel, Copula, U; candidates=:default, criterion=:default, method=:default, kwargs...)
+    fit(CopulaModel, Copula, U; candidates, criterion=:bic, method=:default, kwargs...)
 
-Fit candidate copula families to the `d x n` pseudo-observation matrix `U`,
-select the family minimizing the requested information criterion, and return
-the selected model.
+Fit an explicit collection of candidate families and select the smallest finite
+information criterion (`:bic`, `:aic`, `:aicc`, or `:hqc`). The winning fit is
+reused; only its requested inference is computed afterwards. Prefer maximum
+likelihood fitting when interpreting these as information criteria.
 
-Candidate fits used only for comparison are performed with `vcov=false`. The
-winning family is fitted once with the inference options requested by the user.
+Failed candidates are recorded with `on_error=:skip`, or rethrown with
+`on_error=:throw`. Interruptions always propagate. Composite GOF after selection
+is not yet supported.
 """
 function Distributions.fit(::Type{CopulaModel}, ::Type{Copula}, U;
-        candidates=:default, criterion::Symbol=:default, method::Symbol=:default,
+        candidates, criterion::Symbol=:bic, method::Symbol=:default,
         on_error::Symbol=:skip, require_convergence::Bool=true,
         quick_fit::Bool=false, derived_measures::Bool=true, vcov::Bool=true,
         vcov_method=nothing, kwargs...)
-    d, _ = size(U)
-    available_criteria = _available_selection_criteria()
-    criterion = criterion === :default ? first(available_criteria) : criterion
-    criterion in available_criteria ||
-        throw(ArgumentError("Criterion '$criterion' is not available. Available: $(join(available_criteria, ", "))."))
-    on_error in (:skip, :throw) || throw(ArgumentError("`on_error` must be either `:skip` or `:throw`."))
-
-    candidate_types = _selection_candidates(candidates, d)
+    criterion in (:bic, :aic, :aicc, :hqc) ||
+        throw(ArgumentError("Unknown selection criterion: $criterion"))
+    on_error in (:skip, :throw) ||
+        throw(ArgumentError("`on_error` must be :skip or :throw."))
+    allowed_vcov = (:hessian, :godambe, :godambe_pairwise, :jackknife, :bootstrap)
+    isnothing(vcov_method) || vcov_method in allowed_vcov ||
+        throw(ArgumentError("unknown vcov method `$vcov_method`"))
+    candidate_types = collect(candidates)
+    isempty(candidate_types) && throw(ArgumentError("at least one candidate is required"))
+    all(CT -> CT isa Type && CT <: Copula && CT !== Copula, candidate_types) ||
+        throw(ArgumentError("candidates must be concrete copula families, not Copula itself"))
+    unique!(candidate_types)
 
     rows = NamedTuple[]
-    best_type = nothing
-    best_method = nothing
-    best_score = Inf
+    best = nothing
     best_index = 0
-    selection_start = time()
-
+    best_score = Inf
+    started = time()
     for CT in candidate_types
-        CT <: Copula || throw(ArgumentError("Candidate `$CT` is not a subtype of `Copula`."))
-        CT === Copula && throw(ArgumentError("`Copula` cannot itself appear inside `candidates`."))
-        try
-            M = Distributions.fit(CopulaModel, CT, U; method=method,
-                quick_fit=false, derived_measures=false, vcov=false, kwargs...)
-            aic_value = StatsBase.aic(M)
-            aicc_value = aicc(M)
-            bic_value = StatsBase.bic(M)
-            hqc_value = hqc(M)
-            score =
-                criterion === :bic  ? bic_value :
-                criterion === :aic  ? aic_value :
-                criterion === :aicc ? aicc_value : hqc_value
-            status =
-                !isfinite(M.ll) || !isfinite(score) ? :nonfinite :
-                require_convergence && !M.converged ? :not_converged :
-                :ok
-            if status === :nonfinite
-                aic_value = isfinite(aic_value) ? aic_value : Inf
-                aicc_value = isfinite(aicc_value) ? aicc_value : Inf
-                bic_value = isfinite(bic_value) ? bic_value : Inf
-                hqc_value = isfinite(hqc_value) ? hqc_value : Inf
-                score = Inf
-            end
-            push!(rows, (candidate=CT, status=status, method=M.method,
-                converged=M.converged, nparams=StatsBase.dof(M),
-                loglikelihood=M.ll, aic=aic_value, aicc=aicc_value,
-                bic=bic_value, hqc=hqc_value,
-                criterion_value=score, elapsed_sec=M.elapsed_sec,
-                error=nothing))
-            if status === :ok && score < best_score
-                best_type = CT
-                best_method = M.method
-                best_score = score
-                best_index = length(rows)
-            end
+        M = try
+            Distributions.fit(CopulaModel, CT, U; method,
+                derived_measures=false, vcov=false, kwargs...)
         catch err
-            on_error === :throw && rethrow()
+            (err isa InterruptException || on_error === :throw) && rethrow()
             push!(rows, (candidate=CT, status=:failed, method=method,
                 converged=false, nparams=0, loglikelihood=NaN,
                 aic=Inf, aicc=Inf, bic=Inf, hqc=Inf,
-                criterion_value=Inf, elapsed_sec=NaN,
                 error=sprint(showerror, err)))
+            continue
+        end
+        criteria = (; aic=StatsBase.aic(M), aicc=aicc(M),
+            bic=StatsBase.bic(M), hqc=hqc(M))
+        score = getproperty(criteria, criterion)
+        status = !isfinite(M.ll) || !isfinite(score) ? :nonfinite :
+            require_convergence && !M.converged ? :not_converged : :ok
+        push!(rows, (; candidate=CT, status, method=M.method,
+            converged=M.converged, nparams=StatsBase.dof(M),
+            loglikelihood=M.ll, criteria..., error=nothing))
+        if status === :ok && score < best_score
+            best, best_index, best_score = M, length(rows), score
         end
     end
+    best === nothing && throw(ArgumentError("No candidate copula produced an eligible finite fit."))
+    quick_fit && return (result=best.result,)
 
-    best_type === nothing && throw(ErrorException("No candidate copula produced an eligible finite fit."))
-    selected = Distributions.fit(CopulaModel, best_type, U; method=best_method,
-        quick_fit=quick_fit, derived_measures=derived_measures, vcov=vcov,
-        vcov_method=vcov_method, kwargs...)
-    quick_fit && return selected
-
-    elapsed_sec = time() - selection_start
+    CT = rows[best_index].candidate
+    selected = _finish_copula_fit(CT, best.result, U, best.ll, best.method,
+        best.method_details, best.elapsed_sec, nothing;
+        derived_measures, vcov, vcov_method)
+    # No single-family fit specification can reproduce model selection. Until
+    # selection-aware bootstrap exists, _refit must reject this model.
     return CopulaModel(selected.result, selected.n, selected.ll, selected.method;
-        vcov=selected.vcov,
-        converged=selected.converged,
-        iterations=selected.iterations,
-        elapsed_sec=elapsed_sec,
-        method_details=(; selected.method_details...,
-            selection=true,
-            criterion=criterion,
-            candidates=candidate_types,
-            requested_method=method,
-            selection_options=(; on_error, require_convergence, kwargs...),
-            selection_table=rows,
-            selected_family=best_type,
-            selected_index=best_index,
-            selected_score=best_score,
-            selection_elapsed_sec=elapsed_sec))
+        vcov=selected.vcov, converged=selected.converged,
+        iterations=selected.iterations, elapsed_sec=time() - started,
+        method_details=(; selected.method_details..., criterion,
+            selection_table=rows, selected_index=best_index))
 end

--- a/src/Fitting.jl
+++ b/src/Fitting.jl
@@ -722,12 +722,12 @@ end
 """
     selectiontable(model::CopulaModel)
 
-Return the vector of candidate comparison rows from automatic family selection.
+Return a copy of the vector of candidate comparison rows from automatic family selection.
 """
 function selectiontable(M::CopulaModel)
     haskey(M.method_details, :selection_table) ||
         throw(ArgumentError("The model was not produced by automatic copula selection."))
-    return M.method_details.selection_table
+    return copy(M.method_details.selection_table)
 end
 
 """
@@ -794,7 +794,8 @@ function Distributions.fit(::Type{CopulaModel}, ::Type{Copula}, U;
 
     CT = rows[best_index].candidate
     selected = _finish_copula_fit(CT, best.result, U, best.ll, best.method,
-        best.method_details, best.elapsed_sec, nothing;
+        (; best.method_details..., converged=best.converged, iterations=best.iterations),
+        best.elapsed_sec, nothing;
         derived_measures, vcov, vcov_method)
     # No single-family fit specification can reproduce model selection. Until
     # selection-aware bootstrap exists, _refit must reject this model.

--- a/src/Fitting.jl
+++ b/src/Fitting.jl
@@ -256,7 +256,6 @@ function Distributions.fit(::Type{CopulaModel}, CT::Type{<:Copula}, U;
         derived_measures, vcov, vcov_method)
 end
 
-# Assemble inference around an existing fit, without rerunning its estimator.
 function _check_vcov_method(method)
     allowed = (:hessian, :godambe, :godambe_pairwise, :jackknife, :bootstrap)
     isnothing(method) || method in allowed ||
@@ -264,6 +263,7 @@ function _check_vcov_method(method)
     return nothing
 end
 
+# Assemble inference around an existing fit, without rerunning its estimator.
 function _finish_copula_fit(CT, C, U, ll, method, meta, t, fit_spec;
         derived_measures=true, vcov=true, vcov_method=nothing)
     d, n = size(U)

--- a/src/Fitting.jl
+++ b/src/Fitting.jl
@@ -705,3 +705,224 @@ function StatsBase.predict(M::CopulaModel; newdata=nothing, what=:cdf, nsim=0)
            what === :pdf      ? (newdata === nothing ? throw(ArgumentError("`newdata` required for `:pdf`")) : Distributions.pdf(C, newdata)) :
            throw(ArgumentError("`what` must be one of :simulate, :cdf, or :pdf. Got `$what`."))
 end
+
+###############################################################################
+##### Automatic copula-family selection
+###############################################################################
+
+"""
+    _available_selection_criteria()
+
+Return the information criteria available for automatic copula selection.
+The first entry is used when `criterion=:default`.
+"""
+_available_selection_criteria() = (:bic, :aic, :aicc, :hqc)
+
+struct CopulaSelectionTable{T,R<:AbstractVector{T}} <: AbstractVector{T}
+    rows::R
+    criterion::Symbol
+    selected_family
+end
+
+Base.IndexStyle(::Type{<:CopulaSelectionTable}) = IndexLinear()
+Base.size(table::CopulaSelectionTable) = size(table.rows)
+Base.getindex(table::CopulaSelectionTable, i::Int) = table.rows[i]
+Base.sort(table::CopulaSelectionTable; kwargs...) =
+    CopulaSelectionTable(sort(table.rows; kwargs...), table.criterion, table.selected_family)
+
+"""
+    _default_copula_candidates(d)
+
+Return the built-in parametric copula families considered by automatic
+selection in dimension `d` when `candidates=:default`.
+"""
+function _default_copula_candidates(d::Integer)
+    common = (
+        GaussianCopula,
+        TCopula,
+        AMHCopula,
+        ClaytonCopula,
+        FrankCopula,
+        GumbelCopula,
+        JoeCopula,
+        GalambosCopula,
+        HuslerReissCopula,
+        LogCopula,
+    )
+    d == 2 && return (common..., PlackettCopula)
+    return common
+end
+
+"""
+    _all_copula_candidates(d)
+
+Return the broad built-in parametric copula repertoire considered by automatic
+selection when `candidates=:all`.
+"""
+function _all_copula_candidates(d::Integer)
+    common = (
+        IndependentCopula,
+        GaussianCopula,
+        TCopula,
+        AMHCopula,
+        ClaytonCopula,
+        FrankCopula,
+        GumbelCopula,
+        GumbelBarnettCopula,
+        InvGaussianCopula,
+        JoeCopula,
+        BB1Copula,
+        BB2Copula,
+        BB3Copula,
+        BB6Copula,
+        BB7Copula,
+        BB8Copula,
+        BB9Copula,
+        BB10Copula,
+        RafteryCopula,
+        GalambosCopula,
+        HuslerReissCopula,
+        LogCopula,
+        CuadrasAugeCopula,
+        MixedCopula,
+        MOCopula,
+        TawnCopula,
+    )
+    d == 2 && return (
+        common...,
+        PlackettCopula,
+        FGMCopula,
+        BB4Copula,
+        BB5Copula,
+        AsymGalambosCopula,
+        AsymLogCopula,
+        AsymMixedCopula,
+        BC2Copula,
+    )
+    return common
+end
+
+function _selection_candidates(candidates, d::Integer)
+    candidates === :default && return _default_copula_candidates(d)
+    candidates === :all && return _all_copula_candidates(d)
+    return (candidates isa Type || candidates isa UnionAll) ? (candidates,) : Tuple(candidates)
+end
+
+"""
+    selectiontable(model::CopulaModel)
+
+Return the candidate-comparison table stored in an automatically selected
+copula model.
+"""
+function selectiontable(M::CopulaModel)
+    get(M.method_details, :selection, false) ||
+        throw(ArgumentError("The model was not produced by automatic copula selection."))
+    return CopulaSelectionTable(
+        M.method_details.selection_table,
+        M.method_details.criterion,
+        M.method_details.selected_family,
+    )
+end
+
+"""
+    fit(CopulaModel, Copula, U; candidates=:default, criterion=:default, method=:default, kwargs...)
+
+Fit candidate copula families to the `d x n` pseudo-observation matrix `U`,
+select the family minimizing the requested information criterion, and return
+the selected model.
+
+Candidate fits used only for comparison are performed with `vcov=false`. The
+winning family is fitted once with the inference options requested by the user.
+"""
+function Distributions.fit(::Type{CopulaModel}, ::Type{Copula}, U;
+        candidates=:default, criterion::Symbol=:default, method::Symbol=:default,
+        on_error::Symbol=:skip, require_convergence::Bool=true,
+        quick_fit::Bool=false, derived_measures::Bool=true, vcov::Bool=true,
+        vcov_method=nothing, kwargs...)
+    d, _ = size(U)
+    available_criteria = _available_selection_criteria()
+    criterion = criterion === :default ? first(available_criteria) : criterion
+    criterion in available_criteria ||
+        throw(ArgumentError("Criterion '$criterion' is not available. Available: $(join(available_criteria, ", "))."))
+    on_error in (:skip, :throw) || throw(ArgumentError("`on_error` must be either `:skip` or `:throw`."))
+
+    candidate_types = _selection_candidates(candidates, d)
+
+    rows = NamedTuple[]
+    best_type = nothing
+    best_method = nothing
+    best_score = Inf
+    best_index = 0
+    selection_start = time()
+
+    for CT in candidate_types
+        CT <: Copula || throw(ArgumentError("Candidate `$CT` is not a subtype of `Copula`."))
+        CT === Copula && throw(ArgumentError("`Copula` cannot itself appear inside `candidates`."))
+        try
+            M = Distributions.fit(CopulaModel, CT, U; method=method,
+                quick_fit=false, derived_measures=false, vcov=false, kwargs...)
+            aic_value = StatsBase.aic(M)
+            aicc_value = aicc(M)
+            bic_value = StatsBase.bic(M)
+            hqc_value = hqc(M)
+            score =
+                criterion === :bic  ? bic_value :
+                criterion === :aic  ? aic_value :
+                criterion === :aicc ? aicc_value : hqc_value
+            status =
+                !isfinite(M.ll) || !isfinite(score) ? :nonfinite :
+                require_convergence && !M.converged ? :not_converged :
+                :ok
+            if status === :nonfinite
+                aic_value = isfinite(aic_value) ? aic_value : Inf
+                aicc_value = isfinite(aicc_value) ? aicc_value : Inf
+                bic_value = isfinite(bic_value) ? bic_value : Inf
+                hqc_value = isfinite(hqc_value) ? hqc_value : Inf
+                score = Inf
+            end
+            push!(rows, (candidate=CT, status=status, method=M.method,
+                converged=M.converged, nparams=StatsBase.dof(M),
+                loglikelihood=M.ll, aic=aic_value, aicc=aicc_value,
+                bic=bic_value, hqc=hqc_value,
+                criterion_value=score, elapsed_sec=M.elapsed_sec,
+                error=nothing))
+            if status === :ok && score < best_score
+                best_type = CT
+                best_method = M.method
+                best_score = score
+                best_index = length(rows)
+            end
+        catch err
+            on_error === :throw && rethrow()
+            push!(rows, (candidate=CT, status=:failed, method=method,
+                converged=false, nparams=0, loglikelihood=NaN,
+                aic=Inf, aicc=Inf, bic=Inf, hqc=Inf,
+                criterion_value=Inf, elapsed_sec=NaN,
+                error=sprint(showerror, err)))
+        end
+    end
+
+    best_type === nothing && throw(ErrorException("No candidate copula produced an eligible finite fit."))
+    selected = Distributions.fit(CopulaModel, best_type, U; method=best_method,
+        quick_fit=quick_fit, derived_measures=derived_measures, vcov=vcov,
+        vcov_method=vcov_method, kwargs...)
+    quick_fit && return selected
+
+    elapsed_sec = time() - selection_start
+    return CopulaModel(selected.result, selected.n, selected.ll, selected.method;
+        vcov=selected.vcov,
+        converged=selected.converged,
+        iterations=selected.iterations,
+        elapsed_sec=elapsed_sec,
+        method_details=(; selected.method_details...,
+            selection=true,
+            criterion=criterion,
+            candidates=candidate_types,
+            requested_method=method,
+            selection_options=(; on_error, require_convergence, kwargs...),
+            selection_table=rows,
+            selected_family=best_type,
+            selected_index=best_index,
+            selected_score=best_score,
+            selection_elapsed_sec=elapsed_sec))
+end

--- a/src/Fitting.jl
+++ b/src/Fitting.jl
@@ -243,9 +243,7 @@ C = fit(GumbelCopula, U; method=:itau)
 function Distributions.fit(::Type{CopulaModel}, CT::Type{<:Copula}, U;
         method=:default, quick_fit=false, derived_measures=true,
         vcov=true, vcov_method=nothing, kwargs...)
-    allowed_vcov = (:hessian, :godambe, :godambe_pairwise, :jackknife, :bootstrap)
-    isnothing(vcov_method) || vcov_method in allowed_vcov ||
-        throw(ArgumentError("unknown vcov method `$vcov_method`; expected one of $allowed_vcov"))
+    _check_vcov_method(vcov_method)
     d, n = size(U)
     method = _find_method(CT, d, method)
     fit_spec = _CopulaFitSpec(CT, method, (; kwargs...))
@@ -259,6 +257,13 @@ function Distributions.fit(::Type{CopulaModel}, CT::Type{<:Copula}, U;
 end
 
 # Assemble inference around an existing fit, without rerunning its estimator.
+function _check_vcov_method(method)
+    allowed = (:hessian, :godambe, :godambe_pairwise, :jackknife, :bootstrap)
+    isnothing(method) || method in allowed ||
+        throw(ArgumentError("unknown vcov method `$method`; expected one of $allowed"))
+    return nothing
+end
+
 function _finish_copula_fit(CT, C, U, ll, method, meta, t, fit_spec;
         derived_measures=true, vcov=true, vcov_method=nothing)
     d, n = size(U)
@@ -751,9 +756,7 @@ function Distributions.fit(::Type{CopulaModel}, ::Type{Copula}, U;
         throw(ArgumentError("Unknown selection criterion: $criterion"))
     on_error in (:skip, :throw) ||
         throw(ArgumentError("`on_error` must be :skip or :throw."))
-    allowed_vcov = (:hessian, :godambe, :godambe_pairwise, :jackknife, :bootstrap)
-    isnothing(vcov_method) || vcov_method in allowed_vcov ||
-        throw(ArgumentError("unknown vcov method `$vcov_method`"))
+    _check_vcov_method(vcov_method)
     candidate_types = collect(candidates)
     isempty(candidate_types) && throw(ArgumentError("at least one candidate is required"))
     all(CT -> CT isa Type && CT <: Copula && CT !== Copula, candidate_types) ||
@@ -766,9 +769,12 @@ function Distributions.fit(::Type{CopulaModel}, ::Type{Copula}, U;
     best_score = Inf
     started = time()
     for CT in candidate_types
-        M = try
-            Distributions.fit(CopulaModel, CT, U; method,
+        evaluated = try
+            M = Distributions.fit(CopulaModel, CT, U; method,
                 derived_measures=false, vcov=false, kwargs...)
+            criteria = (; aic=StatsBase.aic(M), aicc=aicc(M),
+                bic=StatsBase.bic(M), hqc=hqc(M))
+            (M, criteria, StatsBase.dof(M))
         catch err
             (err isa InterruptException || on_error === :throw) && rethrow()
             push!(rows, (candidate=CT, status=:failed, method=method,
@@ -777,13 +783,12 @@ function Distributions.fit(::Type{CopulaModel}, ::Type{Copula}, U;
                 error=sprint(showerror, err)))
             continue
         end
-        criteria = (; aic=StatsBase.aic(M), aicc=aicc(M),
-            bic=StatsBase.bic(M), hqc=hqc(M))
+        M, criteria, nparams = evaluated
         score = getproperty(criteria, criterion)
         status = !isfinite(M.ll) || !isfinite(score) ? :nonfinite :
             require_convergence && !M.converged ? :not_converged : :ok
         push!(rows, (; candidate=CT, status, method=M.method,
-            converged=M.converged, nparams=StatsBase.dof(M),
+            converged=M.converged, nparams,
             loglikelihood=M.ll, criteria..., error=nothing))
         if status === :ok && score < best_score
             best, best_index, best_score = M, length(rows), score

--- a/src/show.jl
+++ b/src/show.jl
@@ -183,6 +183,13 @@ function Base.show(io::IO, M::CopulaModel)
     end
     _kv(io, "Number of observations", Printf.@sprintf("%d", StatsBase.nobs(M)))
 
+    if haskey(M.method_details, :selection_table)
+        md = M.method_details
+        _section(io, "Model selection")
+        _kv(io, "Criterion", uppercase(String(md.criterion)))
+        _kv(io, "Selected family", string(md.selection_table[md.selected_index].candidate))
+    end
+
     _section(io, "Fit metrics")
     ll  = M.ll
     ll0 = get(M.method_details, :null_ll, NaN)

--- a/test/operations/fitting_selection.jl
+++ b/test/operations/fitting_selection.jl
@@ -7,7 +7,7 @@ function Distributions.fit(::Type{CopulaModel}, ::Type{SelectionProbe{mode}}, U;
     mode === :interrupt && throw(InterruptException())
     return CopulaModel(IndependentCopula{2}(), size(U, 2),
         mode === :nonfinite ? NaN : 0.0, :probe;
-        converged=mode !== :not_converged, method_details=(; U))
+        converged=mode !== :not_converged, iterations=7, method_details=(; U))
 end
 
 @testset "Automatic copula-family selection" begin
@@ -23,6 +23,10 @@ end
     @test loglikelihood(M) == table[M.method_details.selected_index].loglikelihood
     @test M.result isa ClaytonCopula
     @test occursin("Model selection", sprint(show, M))
+    displayed = sprint(show, M)
+    reverse!(table)
+    @test getproperty.(selectiontable(M), :candidate) == collect(candidates)
+    @test sprint(show, M) == displayed
     @test_throws ArgumentError GOFCopulaTest(M; N=1)
     @test_throws ArgumentError GOFCopulaTest(M, U; N=1)
 
@@ -49,6 +53,7 @@ end
         relaxed = fit(CopulaModel, Copula, U;
             candidates=(SelectionProbe{:not_converged},), require_convergence=false, vcov=false)
         @test !relaxed.converged
+        @test relaxed.iterations == 7
         @test only(selectiontable(relaxed)).status === :ok
         @test_throws ArgumentError selectiontable(
             fit(CopulaModel, IndependentCopula, U; vcov=false))

--- a/test/operations/fitting_selection.jl
+++ b/test/operations/fitting_selection.jl
@@ -1,0 +1,146 @@
+# Selection decisions and public fitting API; numerical fitting oracles live in fitting.jl.
+@testset "Automatic copula-family selection" begin
+    U = rand(rng, ClaytonCopula(2, 6.0), 300)
+
+    candidates = (
+        IndependentCopula,
+        ClaytonCopula,
+    )
+
+    @testset "BIC selection" begin
+        M = fit(
+            CopulaModel,
+            Copula,
+            U;
+            candidates=candidates,
+            criterion=:bic,
+            vcov=false,
+        )
+
+        @test M isa CopulaModel
+        @test M.method_details.selection === true
+        @test M.method_details.criterion === :bic
+        @test M.method_details.candidates == candidates
+        @test M.method_details.selected_family === ClaytonCopula
+        @test M.method_details.selected_index in eachindex(candidates)
+        @test isfinite(M.method_details.selected_score)
+
+        table = selectiontable(M)
+
+        @test table isa AbstractVector
+        @test length(table) == length(candidates)
+        @test table.criterion === :bic
+        @test table.selected_family === ClaytonCopula
+
+        @test [row.candidate for row in table] == collect(candidates)
+        @test all(row -> row.status === :ok, table)
+        @test all(row -> isfinite(row.loglikelihood), table)
+        @test all(row -> isfinite(row.bic), table)
+
+        selected_row = only(filter(
+            row -> row.candidate === ClaytonCopula,
+            table,
+        ))
+
+        @test selected_row.bic == minimum(row.bic for row in table)
+        @test M.method_details.selected_score == selected_row.bic
+    end
+
+    @testset "Selection table display" begin
+        M = fit(
+            CopulaModel,
+            Copula,
+            U;
+            candidates=candidates,
+            vcov=false,
+        )
+
+        table = selectiontable(M)
+
+        io = IOBuffer()
+        show(io, MIME("text/plain"), table)
+        printed = String(take!(io))
+
+        @test occursin("Copula model selection", printed)
+        @test occursin("BIC", printed)
+        @test occursin("IndependentCopula", printed)
+        @test occursin("ClaytonCopula", printed)
+        @test occursin("selected model", printed)
+
+        io = IOBuffer()
+        show(io, MIME("text/plain"), M)
+        printed = String(take!(io))
+
+        @test occursin("Model selection", printed)
+        @test occursin("Criterion:", printed)
+        @test occursin("Selected family:", printed)
+    end
+
+    @testset "Information criteria" begin
+        for criterion in (:aic, :aicc, :hqc)
+            M = fit(
+                CopulaModel,
+                Copula,
+                U;
+                candidates=candidates,
+                criterion=criterion,
+                vcov=false,
+            )
+
+            table = selectiontable(M)
+
+            @test M.method_details.criterion === criterion
+            @test table.criterion === criterion
+
+            eligible = filter(row -> row.status === :ok, table)
+            values = getproperty.(eligible, criterion)
+
+            @test M.method_details.selected_score == minimum(values)
+        end
+    end
+
+    @testset "API errors" begin
+        fitted = fit(
+            CopulaModel,
+            ClaytonCopula,
+            U;
+            vcov=false,
+        )
+
+        @test_throws ArgumentError selectiontable(fitted)
+
+        @test_throws ArgumentError fit(
+            CopulaModel,
+            Copula,
+            U;
+            candidates=candidates,
+            criterion=:invalid,
+            vcov=false,
+        )
+
+        @test_throws ArgumentError fit(
+            CopulaModel,
+            Copula,
+            U;
+            candidates=candidates,
+            on_error=:invalid,
+            vcov=false,
+        )
+
+        @test_throws ArgumentError fit(
+            CopulaModel,
+            Copula,
+            U;
+            candidates=(Normal,),
+            vcov=false,
+        )
+
+        @test_throws ArgumentError fit(
+            CopulaModel,
+            Copula,
+            U;
+            candidates=(Copula,),
+            vcov=false,
+        )
+    end
+end

--- a/test/operations/fitting_selection.jl
+++ b/test/operations/fitting_selection.jl
@@ -1,6 +1,6 @@
 # Public selection contract and selection-specific decisions. Estimator accuracy
 # is tested in fitting.jl; reuse fits here rather than duplicating those oracles.
-struct SelectionProbe{mode} <: Copula{2} end
+struct SelectionProbe{mode} <: Copulas.Copula{2} end
 const SELECTION_PROBE_CALLS = Ref(0)
 function Distributions.fit(::Type{CopulaModel}, ::Type{SelectionProbe{mode}}, U; kwargs...) where {mode}
     SELECTION_PROBE_CALLS[] += 1
@@ -15,7 +15,7 @@ StatsBase.coef(::CopulaModel{SelectionProbe{:bad_score}}) = throw(ArgumentError(
 @testset "Automatic copula-family selection" begin
     U = rand(StableRNG(436), ClaytonCopula{2}(6.0), 80)
     candidates = (IndependentCopula, ClaytonCopula)
-    M = fit(CopulaModel, Copula, U; candidates, vcov=false, derived_measures=false)
+    M = fit(CopulaModel, Copulas.Copula, U; candidates, vcov=false, derived_measures=false)
     table = selectiontable(M)
     @test M isa CopulaModel
     @test table isa Vector
@@ -35,7 +35,7 @@ StatsBase.coef(::CopulaModel{SelectionProbe{:bad_score}}) = throw(ArgumentError(
     @testset "Deferred covariance matches ordinary fitting" begin
         ordinary = fit(CopulaModel, ClaytonCopula, U;
             method=:mle, vcov=true, vcov_method=:hessian, derived_measures=false)
-        selected = fit(CopulaModel, Copula, U; candidates=(ClaytonCopula,),
+        selected = fit(CopulaModel, Copulas.Copula, U; candidates=(ClaytonCopula,),
             method=:mle, vcov=true, vcov_method=:hessian, derived_measures=false)
         @test StatsBase.coef(selected) ≈ StatsBase.coef(ordinary)
         @test loglikelihood(selected) ≈ loglikelihood(ordinary)
@@ -48,7 +48,7 @@ StatsBase.coef(::CopulaModel{SelectionProbe{:bad_score}}) = throw(ArgumentError(
     end
 
     @testset "Information criterion $criterion" for criterion in (:aic, :aicc, :hqc)
-        selected = fit(CopulaModel, Copula, U; candidates, criterion,
+        selected = fit(CopulaModel, Copulas.Copula, U; candidates, criterion,
             vcov=false, derived_measures=false)
         rows = selectiontable(selected)
         @test getproperty(rows[selected.method_details.selected_index], criterion) ==
@@ -56,47 +56,47 @@ StatsBase.coef(::CopulaModel{SelectionProbe{:bad_score}}) = throw(ArgumentError(
     end
 
     @testset "Validation and failed candidates" begin
-        score_failure = fit(CopulaModel, Copula, U;
+        score_failure = fit(CopulaModel, Copulas.Copula, U;
             candidates=(SelectionProbe{:bad_score}, IndependentCopula), vcov=false)
         @test first(selectiontable(score_failure)).status === :failed
         @test occursin("unavailable parameter count", first(selectiontable(score_failure)).error)
-        @test_throws ArgumentError fit(CopulaModel, Copula, U;
+        @test_throws ArgumentError fit(CopulaModel, Copulas.Copula, U;
             candidates=(SelectionProbe{:bad_score},), on_error=:throw)
         SELECTION_PROBE_CALLS[] = 0
-        fit(CopulaModel, Copula, U; candidates=(SelectionProbe{:ok},), vcov=false)
+        fit(CopulaModel, Copulas.Copula, U; candidates=(SelectionProbe{:ok},), vcov=false)
         @test SELECTION_PROBE_CALLS[] == 1
-        @test_throws InterruptException fit(CopulaModel, Copula, U;
+        @test_throws InterruptException fit(CopulaModel, Copulas.Copula, U;
             candidates=(SelectionProbe{:interrupt},), vcov=false)
         for mode in (:nonfinite, :not_converged)
-            probe = fit(CopulaModel, Copula, U;
+            probe = fit(CopulaModel, Copulas.Copula, U;
                 candidates=(SelectionProbe{mode}, IndependentCopula), vcov=false)
             @test selectiontable(probe)[1].status === mode
             @test probe.method_details.selected_index == 2
         end
-        relaxed = fit(CopulaModel, Copula, U;
+        relaxed = fit(CopulaModel, Copulas.Copula, U;
             candidates=(SelectionProbe{:not_converged},), require_convergence=false, vcov=false)
         @test !relaxed.converged
         @test relaxed.iterations == 7
         @test only(selectiontable(relaxed)).status === :ok
         @test_throws ArgumentError selectiontable(
             fit(CopulaModel, IndependentCopula, U; vcov=false))
-        @test_throws ArgumentError fit(CopulaModel, Copula, U; candidates=())
-        @test_throws ArgumentError fit(CopulaModel, Copula, U; candidates=(Normal,))
-        @test_throws ArgumentError fit(CopulaModel, Copula, U; candidates=(Copula,))
-        @test_throws ArgumentError fit(CopulaModel, Copula, U; candidates, criterion=:invalid)
-        @test_throws ArgumentError fit(CopulaModel, Copula, U; candidates, on_error=:invalid)
-        @test_throws ArgumentError fit(CopulaModel, Copula, U; candidates, vcov_method=:invalid)
+        @test_throws ArgumentError fit(CopulaModel, Copulas.Copula, U; candidates=())
+        @test_throws ArgumentError fit(CopulaModel, Copulas.Copula, U; candidates=(Normal,))
+        @test_throws ArgumentError fit(CopulaModel, Copulas.Copula, U; candidates=(Copulas.Copula,))
+        @test_throws ArgumentError fit(CopulaModel, Copulas.Copula, U; candidates, criterion=:invalid)
+        @test_throws ArgumentError fit(CopulaModel, Copulas.Copula, U; candidates, on_error=:invalid)
+        @test_throws ArgumentError fit(CopulaModel, Copulas.Copula, U; candidates, vcov_method=:invalid)
         # Abstract families cannot be fitted without a model specification.
         invalid = (Copulas.SubsetCopula, IndependentCopula)
-        skipped = fit(CopulaModel, Copula, U; candidates=invalid, vcov=false)
+        skipped = fit(CopulaModel, Copulas.Copula, U; candidates=invalid, vcov=false)
         @test selectiontable(skipped)[1].status === :failed
         @test selectiontable(skipped)[2].status === :ok
-        @test_throws ArgumentError fit(CopulaModel, Copula, U;
+        @test_throws ArgumentError fit(CopulaModel, Copulas.Copula, U;
             candidates=invalid, on_error=:throw)
-        @test_throws ArgumentError fit(CopulaModel, Copula, U; candidates=(Copulas.SubsetCopula,))
-        @test fit(Copula, U; candidates=(IndependentCopula,)) isa IndependentCopula
+        @test_throws ArgumentError fit(CopulaModel, Copulas.Copula, U; candidates=(Copulas.SubsetCopula,))
+        @test fit(Copulas.Copula, U; candidates=(IndependentCopula,)) isa IndependentCopula
         # An undefined small-sample AICc excludes the fit.
-        @test_throws ArgumentError fit(CopulaModel, Copula, U[:, 1:1];
+        @test_throws ArgumentError fit(CopulaModel, Copulas.Copula, U[:, 1:1];
             candidates=(IndependentCopula,), criterion=:aicc)
     end
 end

--- a/test/operations/fitting_selection.jl
+++ b/test/operations/fitting_selection.jl
@@ -1,146 +1,74 @@
-# Selection decisions and public fitting API; numerical fitting oracles live in fitting.jl.
+# Public selection contract and selection-specific decisions. Estimator accuracy
+# is tested in fitting.jl; reuse fits here rather than duplicating those oracles.
+struct SelectionProbe{mode} <: Copula{2} end
+const SELECTION_PROBE_CALLS = Ref(0)
+function Distributions.fit(::Type{CopulaModel}, ::Type{SelectionProbe{mode}}, U; kwargs...) where {mode}
+    SELECTION_PROBE_CALLS[] += 1
+    mode === :interrupt && throw(InterruptException())
+    return CopulaModel(IndependentCopula{2}(), size(U, 2),
+        mode === :nonfinite ? NaN : 0.0, :probe;
+        converged=mode !== :not_converged, method_details=(; U))
+end
+
 @testset "Automatic copula-family selection" begin
-    U = rand(rng, ClaytonCopula(2, 6.0), 300)
+    U = rand(StableRNG(436), ClaytonCopula{2}(6.0), 80)
+    candidates = (IndependentCopula, ClaytonCopula)
+    M = fit(CopulaModel, Copula, U; candidates, vcov=false, derived_measures=false)
+    table = selectiontable(M)
+    @test M isa CopulaModel
+    @test table isa Vector
+    @test getproperty.(table, :candidate) == collect(candidates)
+    @test all(row -> row.status === :ok, table)
+    @test table[M.method_details.selected_index].bic == minimum(row.bic for row in table)
+    @test loglikelihood(M) == table[M.method_details.selected_index].loglikelihood
+    @test M.result isa ClaytonCopula
+    @test occursin("Model selection", sprint(show, M))
+    @test_throws ArgumentError GOFCopulaTest(M; N=1)
+    @test_throws ArgumentError GOFCopulaTest(M, U; N=1)
 
-    candidates = (
-        IndependentCopula,
-        ClaytonCopula,
-    )
-
-    @testset "BIC selection" begin
-        M = fit(
-            CopulaModel,
-            Copula,
-            U;
-            candidates=candidates,
-            criterion=:bic,
-            vcov=false,
-        )
-
-        @test M isa CopulaModel
-        @test M.method_details.selection === true
-        @test M.method_details.criterion === :bic
-        @test M.method_details.candidates == candidates
-        @test M.method_details.selected_family === ClaytonCopula
-        @test M.method_details.selected_index in eachindex(candidates)
-        @test isfinite(M.method_details.selected_score)
-
-        table = selectiontable(M)
-
-        @test table isa AbstractVector
-        @test length(table) == length(candidates)
-        @test table.criterion === :bic
-        @test table.selected_family === ClaytonCopula
-
-        @test [row.candidate for row in table] == collect(candidates)
-        @test all(row -> row.status === :ok, table)
-        @test all(row -> isfinite(row.loglikelihood), table)
-        @test all(row -> isfinite(row.bic), table)
-
-        selected_row = only(filter(
-            row -> row.candidate === ClaytonCopula,
-            table,
-        ))
-
-        @test selected_row.bic == minimum(row.bic for row in table)
-        @test M.method_details.selected_score == selected_row.bic
+    @testset "Information criterion $criterion" for criterion in (:aic, :aicc, :hqc)
+        selected = fit(CopulaModel, Copula, U; candidates, criterion,
+            vcov=false, derived_measures=false)
+        rows = selectiontable(selected)
+        @test getproperty(rows[selected.method_details.selected_index], criterion) ==
+            minimum(getproperty(row, criterion) for row in rows)
     end
 
-    @testset "Selection table display" begin
-        M = fit(
-            CopulaModel,
-            Copula,
-            U;
-            candidates=candidates,
-            vcov=false,
-        )
-
-        table = selectiontable(M)
-
-        io = IOBuffer()
-        show(io, MIME("text/plain"), table)
-        printed = String(take!(io))
-
-        @test occursin("Copula model selection", printed)
-        @test occursin("BIC", printed)
-        @test occursin("IndependentCopula", printed)
-        @test occursin("ClaytonCopula", printed)
-        @test occursin("selected model", printed)
-
-        io = IOBuffer()
-        show(io, MIME("text/plain"), M)
-        printed = String(take!(io))
-
-        @test occursin("Model selection", printed)
-        @test occursin("Criterion:", printed)
-        @test occursin("Selected family:", printed)
-    end
-
-    @testset "Information criteria" begin
-        for criterion in (:aic, :aicc, :hqc)
-            M = fit(
-                CopulaModel,
-                Copula,
-                U;
-                candidates=candidates,
-                criterion=criterion,
-                vcov=false,
-            )
-
-            table = selectiontable(M)
-
-            @test M.method_details.criterion === criterion
-            @test table.criterion === criterion
-
-            eligible = filter(row -> row.status === :ok, table)
-            values = getproperty.(eligible, criterion)
-
-            @test M.method_details.selected_score == minimum(values)
+    @testset "Validation and failed candidates" begin
+        SELECTION_PROBE_CALLS[] = 0
+        fit(CopulaModel, Copula, U; candidates=(SelectionProbe{:ok},), vcov=false)
+        @test SELECTION_PROBE_CALLS[] == 1
+        @test_throws InterruptException fit(CopulaModel, Copula, U;
+            candidates=(SelectionProbe{:interrupt},), vcov=false)
+        for mode in (:nonfinite, :not_converged)
+            probe = fit(CopulaModel, Copula, U;
+                candidates=(SelectionProbe{mode}, IndependentCopula), vcov=false)
+            @test selectiontable(probe)[1].status === mode
+            @test probe.method_details.selected_index == 2
         end
-    end
-
-    @testset "API errors" begin
-        fitted = fit(
-            CopulaModel,
-            ClaytonCopula,
-            U;
-            vcov=false,
-        )
-
-        @test_throws ArgumentError selectiontable(fitted)
-
-        @test_throws ArgumentError fit(
-            CopulaModel,
-            Copula,
-            U;
-            candidates=candidates,
-            criterion=:invalid,
-            vcov=false,
-        )
-
-        @test_throws ArgumentError fit(
-            CopulaModel,
-            Copula,
-            U;
-            candidates=candidates,
-            on_error=:invalid,
-            vcov=false,
-        )
-
-        @test_throws ArgumentError fit(
-            CopulaModel,
-            Copula,
-            U;
-            candidates=(Normal,),
-            vcov=false,
-        )
-
-        @test_throws ArgumentError fit(
-            CopulaModel,
-            Copula,
-            U;
-            candidates=(Copula,),
-            vcov=false,
-        )
+        relaxed = fit(CopulaModel, Copula, U;
+            candidates=(SelectionProbe{:not_converged},), require_convergence=false, vcov=false)
+        @test !relaxed.converged
+        @test only(selectiontable(relaxed)).status === :ok
+        @test_throws ArgumentError selectiontable(
+            fit(CopulaModel, IndependentCopula, U; vcov=false))
+        @test_throws ArgumentError fit(CopulaModel, Copula, U; candidates=())
+        @test_throws ArgumentError fit(CopulaModel, Copula, U; candidates=(Normal,))
+        @test_throws ArgumentError fit(CopulaModel, Copula, U; candidates=(Copula,))
+        @test_throws ArgumentError fit(CopulaModel, Copula, U; candidates, criterion=:invalid)
+        @test_throws ArgumentError fit(CopulaModel, Copula, U; candidates, on_error=:invalid)
+        @test_throws ArgumentError fit(CopulaModel, Copula, U; candidates, vcov_method=:invalid)
+        # Abstract families cannot be fitted without a model specification.
+        invalid = (Copulas.SubsetCopula, IndependentCopula)
+        skipped = fit(CopulaModel, Copula, U; candidates=invalid, vcov=false)
+        @test selectiontable(skipped)[1].status === :failed
+        @test selectiontable(skipped)[2].status === :ok
+        @test_throws ArgumentError fit(CopulaModel, Copula, U;
+            candidates=invalid, on_error=:throw)
+        @test_throws ArgumentError fit(CopulaModel, Copula, U; candidates=(Copulas.SubsetCopula,))
+        @test fit(Copula, U; candidates=(IndependentCopula,)) isa IndependentCopula
+        # An undefined small-sample AICc excludes the fit.
+        @test_throws ArgumentError fit(CopulaModel, Copula, U[:, 1:1];
+            candidates=(IndependentCopula,), criterion=:aicc)
     end
 end

--- a/test/operations/fitting_selection.jl
+++ b/test/operations/fitting_selection.jl
@@ -5,10 +5,12 @@ const SELECTION_PROBE_CALLS = Ref(0)
 function Distributions.fit(::Type{CopulaModel}, ::Type{SelectionProbe{mode}}, U; kwargs...) where {mode}
     SELECTION_PROBE_CALLS[] += 1
     mode === :interrupt && throw(InterruptException())
+    mode === :bad_score && return CopulaModel(SelectionProbe{:bad_score}(), size(U, 2), 0.0, :probe)
     return CopulaModel(IndependentCopula{2}(), size(U, 2),
         mode === :nonfinite ? NaN : 0.0, :probe;
         converged=mode !== :not_converged, iterations=7, method_details=(; U))
 end
+StatsBase.coef(::CopulaModel{SelectionProbe{:bad_score}}) = throw(ArgumentError("unavailable parameter count"))
 
 @testset "Automatic copula-family selection" begin
     U = rand(StableRNG(436), ClaytonCopula{2}(6.0), 80)
@@ -39,6 +41,12 @@ end
     end
 
     @testset "Validation and failed candidates" begin
+        score_failure = fit(CopulaModel, Copula, U;
+            candidates=(SelectionProbe{:bad_score}, IndependentCopula), vcov=false)
+        @test first(selectiontable(score_failure)).status === :failed
+        @test occursin("unavailable parameter count", first(selectiontable(score_failure)).error)
+        @test_throws ArgumentError fit(CopulaModel, Copula, U;
+            candidates=(SelectionProbe{:bad_score},), on_error=:throw)
         SELECTION_PROBE_CALLS[] = 0
         fit(CopulaModel, Copula, U; candidates=(SelectionProbe{:ok},), vcov=false)
         @test SELECTION_PROBE_CALLS[] == 1

--- a/test/operations/fitting_selection.jl
+++ b/test/operations/fitting_selection.jl
@@ -22,7 +22,7 @@ StatsBase.coef(::CopulaModel{SelectionProbe{:bad_score}}) = throw(ArgumentError(
     @test getproperty.(table, :candidate) == collect(candidates)
     @test all(row -> row.status === :ok, table)
     @test table[M.method_details.selected_index].bic == minimum(row.bic for row in table)
-    @test loglikelihood(M) == table[M.method_details.selected_index].loglikelihood
+    @test M.ll == table[M.method_details.selected_index].loglikelihood
     @test M.result isa ClaytonCopula
     @test occursin("Model selection", sprint(show, M))
     displayed = sprint(show, M)
@@ -38,7 +38,7 @@ StatsBase.coef(::CopulaModel{SelectionProbe{:bad_score}}) = throw(ArgumentError(
         selected = fit(CopulaModel, Copulas.Copula, U; candidates=(ClaytonCopula,),
             method=:mle, vcov=true, vcov_method=:hessian, derived_measures=false)
         @test StatsBase.coef(selected) ≈ StatsBase.coef(ordinary)
-        @test loglikelihood(selected) ≈ loglikelihood(ordinary)
+        @test selected.ll ≈ ordinary.ll
         @test selected.vcov !== nothing
         @test ordinary.vcov !== nothing
         @test all(isfinite, selected.vcov)

--- a/test/operations/fitting_selection.jl
+++ b/test/operations/fitting_selection.jl
@@ -32,6 +32,21 @@ StatsBase.coef(::CopulaModel{SelectionProbe{:bad_score}}) = throw(ArgumentError(
     @test_throws ArgumentError GOFCopulaTest(M; N=1)
     @test_throws ArgumentError GOFCopulaTest(M, U; N=1)
 
+    @testset "Deferred covariance matches ordinary fitting" begin
+        ordinary = fit(CopulaModel, ClaytonCopula, U;
+            method=:mle, vcov=true, vcov_method=:hessian, derived_measures=false)
+        selected = fit(CopulaModel, Copula, U; candidates=(ClaytonCopula,),
+            method=:mle, vcov=true, vcov_method=:hessian, derived_measures=false)
+        @test StatsBase.coef(selected) ≈ StatsBase.coef(ordinary)
+        @test loglikelihood(selected) ≈ loglikelihood(ordinary)
+        @test selected.vcov !== nothing
+        @test ordinary.vcov !== nothing
+        @test all(isfinite, selected.vcov)
+        @test selected.vcov ≈ ordinary.vcov
+        @test selected.converged == ordinary.converged
+        @test selected.iterations == ordinary.iterations
+    end
+
     @testset "Information criterion $criterion" for criterion in (:aic, :aicc, :hqc)
         selected = fit(CopulaModel, Copula, U; candidates, criterion,
             vcov=false, derived_measures=false)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -209,6 +209,7 @@ testfiles = (
     "operations/rosenblatt.jl",
     "operations/dependence.jl",
     "operations/fitting.jl",
+    "operations/fitting_selection.jl",
     "operations/hypothesis_testing.jl",
     "operations/nataf.jl",
     "extensions/expectation_maximization.jl"


### PR DESCRIPTION
Hi Oskar,

This is the other independent part I mentioned in #435.

I originally developed the hypothesis-testing framework and automatic family selection together, but I think separating them makes the API much easier to review. This PR does not depend on #435, so either one can be merged first.

The idea here is to allow family selection directly through the existing fitting interface:

```julia
M = fit(CopulaModel, Copula, U; candidates=(ClaytonCopula, GumbelCopula, FrankCopula), criterion=:bic,)
```

Instead of introducing a separate model-selection object or fitting abstraction, `Copula` acts as the request to compare candidate families using the same `CopulaModel` machinery that is already available.

The supported criteria are:

* BIC,
* AIC,
* AICc,
* HQC.

The candidate fits are evaluated first without the additional inference cost, the best eligible family is selected according to the requested criterion, and the winning family is then fitted normally with the options requested by the user.

The returned object is still a regular `CopulaModel`, with the additional selection metadata stored in `method_details`.

The complete comparison can be inspected with:

```julia
selectiontable(M)
```

which keeps the candidate family, fitting method, convergence/status information, log-likelihood, number of parameters, and the information criteria for each candidate.

There are also two built-in candidate collections:

```julia
candidates=:default
candidates=:all
```

while an explicit tuple can be used when only a scientifically meaningful subset of families should be considered.

I think this is also a nice example of extending the existing fitting API without introducing another parallel interface: the result still behaves exactly like any other `CopulaModel`.

There is one particularly interesting connection with #435 that I intentionally left out of both PRs.

Once #435 and this PR are merged, a small follow-up could implement goodness-of-fit after model selection. We already had this case in the combined implementation, roughly:

```julia
M = fit(CopulaModel, Copula, U; candidates=(ClaytonCopula, GumbelCopula, FrankCopula), criterion=:bic,)

T = GOFCopulaTest(M)
```

The important point is that this is not the same as ordinary composite GOF. Under automatic model selection, each parametric-bootstrap replicate should reproduce the complete procedure:

```text
simulate from fitted model
        ↓
run family selection again
        ↓
fit the selected family
        ↓
compute the GOF statistic
```

So that follow-up would be a concrete example of the two APIs composing naturally: this PR provides the model-selection procedure, while #435 provides the hypothesis/statistic/calibration framework.

I left that integration out intentionally so both APIs can be reviewed independently first. If both are merged, I can send the selection-aware GOF part as a much smaller follow-up PR.

And no rush with this one either — especially with #434 and #435 already on your plate :)
