### PR TITLE
Preserve numeric types when sampling copulas

### DIFF
--- a/docs/src/api/public.md
+++ b/docs/src/api/public.md
@@ -36,10 +36,11 @@ not.
 | Composition | `SklarDist` | Distribution operations, marginalization, conditioning and Rosenblatt transforms are expressed on the marginal scales. |
 | Utilities | `pseudos`, `measure`, `Nataf` | Rank pseudo-observations, copula rectangle probability, and Nataf correlation correction respectively. |
 
-!!! warning "Known sampling type bug"
-    Numeric-type preservation is part of the intended sampling contract, but
-    some current sampling paths still return `Float64`. This known violation is
-    tracked in [issue #195](https://github.com/lrnv/Copulas.jl/issues/195).
+For continuous distributions, `eltype` follows the Distributions.jl convention:
+it is the default numeric type allocated by `rand`. Parameterized copulas
+propagate the numeric representation of their parameters, composite copulas
+promote their components, and parameter-free copulas default to `Float64`.
+`rand!` may instead target any compatible real-valued buffer type.
 
 Public component constructors guarantee their documented mathematical semantics
 and supported constructor forms. Public status does not expose undocumented fields,

--- a/docs/src/dev/developer_guide.md
+++ b/docs/src/dev/developer_guide.md
@@ -514,6 +514,13 @@ The required public behavior is simply
 rand(C, n)
 ```
 
+Distributions.jl allocates this result in `float(eltype(C))`. A copula that
+stores numeric parameters must therefore define `eltype(C)` from that stored
+representation; wrappers propagate the wrapped copula type and compositions
+promote their components. The generic fallback is `Float64` for genuinely
+parameter-free copulas. In-place `_rand!` implementations must use the element
+type of their output buffer rather than assuming that it equals `eltype(C)`.
+
 Extreme-value sampling is selected directly through Julia dispatch on the
 copula dimension and the concrete tail type. There is no separate sampling
 backend trait or routing layer.

--- a/src/ArchimaxCopula.jl
+++ b/src/ArchimaxCopula.jl
@@ -29,6 +29,7 @@ struct ArchimaxCopula{d, TG, TT} <: Copula{d}
         return new{d, typeof(gen), typeof(tail)}(gen, tail)
     end
 end
+Base.eltype(C::ArchimaxCopula) = promote_type(eltype(C.gen), eltype(C.tail))
 @inline function _archimax_limit_kind(C::ArchimaxCopula{d}) where {d}
     gkind = limit_kind(C.gen, Val(d))
     tkind = limit_kind(C.tail, Val(d))

--- a/src/ArchimedeanCopula.jl
+++ b/src/ArchimedeanCopula.jl
@@ -44,6 +44,7 @@ struct ArchimedeanCopula{d,TG} <: Copula{d}
         return new{d,typeof(G)}(G)
     end
 end
+Base.eltype(C::ArchimedeanCopula) = eltype(C.G)
 
 # Absolute continuity of an Archimedean copula is determined by its radial
 # law, not merely by the generator type. Generic generators are smooth unless

--- a/src/Conditioning.jl
+++ b/src/Conditioning.jl
@@ -190,6 +190,7 @@ struct ConditionalCopula{d, D, p, T, TDs}<:Copula{d}
         )
     end
 end
+Base.eltype(::ConditionalCopula{d,D,p,T}) where {d,D,p,T} = T
 conditional_copula(C::Copula, js, uⱼₛ) = ConditionalCopula(C, js, uⱼₛ)
 function _cdf(CC::ConditionalCopula{d,D,p,T}, v::AbstractVector{<:Real}) where {d,D,p,T}
     uI = ntuple(k -> Distributions.quantile(CC.distortions[k], v[k]), d)

--- a/src/Copula.jl
+++ b/src/Copula.jl
@@ -13,6 +13,11 @@
 ###############################################################################
 abstract type Copula{d} <: Distributions.ContinuousMultivariateDistribution end
 
+# Distributions.jl uses `eltype` as the default element type allocated by
+# `rand`. Parameter-free copulas therefore sample as Float64 unless a concrete
+# family propagates another numeric representation below its own definition.
+Base.eltype(::Copula) = Float64
+
 # Copulas are represented as continuous multivariate distributions for the
 # Distributions.jl API, but their probability measure need not admit a density
 # with respect to Lebesgue measure. This internal trait is the single source of

--- a/src/Copula.jl
+++ b/src/Copula.jl
@@ -17,6 +17,7 @@ abstract type Copula{d} <: Distributions.ContinuousMultivariateDistribution end
 # `rand`. Parameter-free copulas therefore sample as Float64 unless a concrete
 # family propagates another numeric representation below its own definition.
 Base.eltype(::Copula) = Float64
+Distributions.partype(C::Copula) = eltype(C)
 
 # Copulas are represented as continuous multivariate distributions for the
 # Distributions.jl API, but their probability measure need not admit a density

--- a/src/EllipticalCopulas/TCopula.jl
+++ b/src/EllipticalCopulas/TCopula.jl
@@ -32,6 +32,7 @@ struct TCopula{d,Tν,MT} <: EllipticalCopula{d,MT}
         return new{d,typeof(df),typeof(Σ)}(df, Σ)
     end
 end
+Base.eltype(C::TCopula) = promote_type(typeof(float(C.df)), eltype(C.Σ))
 TCopula(ν::Real, Σ::AbstractMatrix) = TCopula{size(Σ, 1)}(ν, Σ)
 TCopula(d::Int, ν::Real, Σ::AbstractMatrix) = TCopula{d}(ν, Σ)
 (::Type{TCopula{D,Tν,MT}})(d::Int, ν::Real, Σ::AbstractMatrix) where {D,Tν,MT} = TCopula{d}(ν, Σ)

--- a/src/ExtremeValueCopula.jl
+++ b/src/ExtremeValueCopula.jl
@@ -258,9 +258,11 @@ function Distributions._rand!(
     kind === Π_LIMIT && return Random.rand!(rng, X)
     kind === M_LIMIT && return _rand_M!(rng, X)
     E = ExtremeDist(C.tail)
+    S = promote_type(T, eltype(C))
     for i in axes(X, 2)
         z = rand(rng, E)
-        w = rand(rng) < _ghoudi_mixture_probability(C.tail, z) ? rand(rng) : rand(rng) * rand(rng)
+        w = rand(rng, S) < _ghoudi_mixture_probability(C.tail, z) ?
+            rand(rng, S) : rand(rng, S) * rand(rng, S)
         a = A(C.tail, z)
         X[1, i] = exp(log(w) * z / a)
         X[2, i] = exp(log(w) * (1 - z) / a)

--- a/src/ExtremeValueCopula.jl
+++ b/src/ExtremeValueCopula.jl
@@ -45,6 +45,7 @@ struct ExtremeValueCopula{d,TT<:Tail} <: Copula{d}
         return new{d,typeof(tail)}(tail)
     end
 end
+Base.eltype(C::ExtremeValueCopula) = eltype(C.tail)
 
 function copula_measure_style(C::ExtremeValueCopula{d}) where {d}
     limit_kind(C.tail, Val(d)) === M_LIMIT &&

--- a/src/Generator.jl
+++ b/src/Generator.jl
@@ -12,6 +12,7 @@ representations and numerical fallbacks are internal implementation details.
 See the developer guide for the current contributor architecture.
 """
 abstract type Generator end
+Base.eltype(G::Generator) = _sample_eltype(G)
 function (TG::Type{<:Generator})(args...;kwargs...)
     S = hasproperty(TG, :body) ? TG.body : TG
     T = S.name.wrapper 

--- a/src/Generator/ClaytonGenerator.jl
+++ b/src/Generator/ClaytonGenerator.jl
@@ -31,6 +31,7 @@ struct ClaytonGenerator{T} <: AbstractUnivariateGenerator
 end
 const ClaytonCopula{d, T} = ArchimedeanCopula{d, ClaytonGenerator{T}}
 @inline function limit_kind(G::ClaytonGenerator, ::Val{d}) where {d}
+    iszero(G.θ) && return Π_LIMIT
     isinf(G.θ) && return M_LIMIT
     d == 2 && G.θ == -1 && return W_LIMIT
     return NO_LIMIT

--- a/src/LiouvilleCopula.jl
+++ b/src/LiouvilleCopula.jl
@@ -43,6 +43,7 @@ struct LiouvilleCopula{d,TG,Tα} <: Copula{d}
         return new{d,typeof(G),eltype(αtuple)}(G, αtuple)
     end
 end
+Base.eltype(C::LiouvilleCopula) = promote_type(eltype(C.G), eltype(C.α))
 
 LiouvilleCopula(G::Generator, α) = LiouvilleCopula{length(α)}(G, α)
 LiouvilleCopula(d::Integer, G::Generator, α) = LiouvilleCopula{d}(G, α)

--- a/src/MiscellaneousCopulas/CheckerboardCopula.jl
+++ b/src/MiscellaneousCopulas/CheckerboardCopula.jl
@@ -37,6 +37,7 @@ struct CheckerboardCopula{d, T} <: Copula{d}
     m::Vector{Int}
     boxes::Dict{NTuple{d,Int}, T}
 end
+Base.eltype(::CheckerboardCopula{d,T}) where {d,T} = T
 function CheckerboardCopula{d}(X::AbstractMatrix{T}; m=nothing, pseudo_values::Bool=true) where {d,T}
     size(X, 1) == d || throw(DimensionMismatch("data must have $d rows"))
     n = size(X, 2)

--- a/src/MiscellaneousCopulas/EmpiricalCopula.jl
+++ b/src/MiscellaneousCopulas/EmpiricalCopula.jl
@@ -28,7 +28,7 @@ copula_measure_style(::Type{<:EmpiricalCopula}) =
 Base.eltype(C::EmpiricalCopula{d,MT}) where {d,MT} = Base.eltype(C.u)
 function EmpiricalCopula{d}(u; pseudo_values=true) where {d}
     size(u, 1) == d || throw(DimensionMismatch("data must have $d rows"))
-    T = promote_type(eltype(u), Float64)
+    T = float(eltype(u))
     u = T.(u)
     if !pseudo_values
         u = pseudos(u)

--- a/src/MiscellaneousCopulas/SurvivalCopula.jl
+++ b/src/MiscellaneousCopulas/SurvivalCopula.jl
@@ -36,6 +36,7 @@ struct SurvivalCopula{d,CT} <: Copula{d}
         return new{d,typeof(C)}(C, mask)
     end
 end
+Base.eltype(C::SurvivalCopula) = eltype(C.C)
 
 function _survival_flipmask(::Val{d}, flips::NTuple{d,Bool}) where {d}
     return flips

--- a/src/NestedArchimedeanCopula.jl
+++ b/src/NestedArchimedeanCopula.jl
@@ -468,6 +468,7 @@ function _tree_param_eltype(C::NestedArchimedeanCopula)
     end
     return T
 end
+Base.eltype(C::NestedArchimedeanCopula) = float(_tree_param_eltype(C))
 
 # Dimension count of a sub-copula entry.
 _subdim(c::ArchimedeanCopula) = length(c)

--- a/src/SklarDist.jl
+++ b/src/SklarDist.jl
@@ -54,7 +54,10 @@ function SklarDist(C::Copula, m)
     return SklarDist(C, margins)
 end
 Base.length(S::SklarDist{CT,TplMargins}) where {CT,TplMargins} = length(S.C)
-Base.eltype(S::SklarDist{CT,TplMargins}) where {CT,TplMargins} = Base.eltype(S.C)
+function Base.eltype(S::SklarDist)
+    T = mapreduce(eltype, promote_type, S.m; init=Union{})
+    return T === Union{} ? Float64 : float(T)
+end
 Distributions.params(S::SklarDist) = (copula=S.C, margins=S.m)
 @inline function _sklar_work_eltype(S::SklarDist, x)
     T = promote_type(eltype(S.C), eltype(x))

--- a/src/SklarDist.jl
+++ b/src/SklarDist.jl
@@ -55,14 +55,14 @@ function SklarDist(C::Copula, m)
 end
 Base.length(S::SklarDist{CT,TplMargins}) where {CT,TplMargins} = length(S.C)
 function Base.eltype(S::SklarDist)
-    T = mapreduce(eltype, promote_type, S.m; init=Union{})
+    T = mapreduce(Distributions.partype, promote_type, S.m; init=Union{})
     return T === Union{} ? Float64 : float(T)
 end
 Distributions.params(S::SklarDist) = (copula=S.C, margins=S.m)
 @inline function _sklar_work_eltype(S::SklarDist, x)
     T = promote_type(eltype(S.C), eltype(x))
     for margin in S.m
-        T = promote_type(T, eltype(margin))
+        T = promote_type(T, Distributions.partype(margin))
     end
     return T
 end

--- a/src/SklarDist.jl
+++ b/src/SklarDist.jl
@@ -58,6 +58,12 @@ function Base.eltype(S::SklarDist)
     T = mapreduce(Distributions.partype, promote_type, S.m; init=Union{})
     return T === Union{} ? Float64 : float(T)
 end
+function Distributions.partype(S::SklarDist)
+    return promote_type(
+        Distributions.partype(S.C),
+        mapreduce(Distributions.partype, promote_type, S.m; init=Union{}),
+    )
+end
 Distributions.params(S::SklarDist) = (copula=S.C, margins=S.m)
 @inline function _sklar_work_eltype(S::SklarDist, x)
     T = promote_type(eltype(S.C), eltype(x))

--- a/src/Tail.jl
+++ b/src/Tail.jl
@@ -16,6 +16,7 @@ conditioning and sampling backends are internal and may require additional
 family-specific conditions. See the developer guide for the current architecture.
 """
 abstract type Tail end
+Base.eltype(tail::Tail) = _sample_eltype(tail)
 function (TT::Type{<:Tail})(args...; kwargs...)
     S = hasproperty(TT, :body) ? TT.body : TT
     T = S.name.wrapper

--- a/src/Tail/AsymLogTail.jl
+++ b/src/Tail/AsymLogTail.jl
@@ -27,7 +27,7 @@ struct AsymLogTail{T} <: BivariatePickandsTail
     θ₁::T
     θ₂::T
     function AsymLogTail(α, θ₁, θ₂)
-        T = promote_type(Float64, typeof(α), typeof(θ₁), typeof(θ₂))
+        T = float(promote_type(typeof(α), typeof(θ₁), typeof(θ₂)))
         θ₁, θ₂, αT = T(θ₁), T(θ₂), T(α)
         (αT ≥ 1) || throw(ArgumentError("α must be ≥ 1"))
         (0 ≤ θ₁ ≤ 1 && 0 ≤ θ₂ ≤ 1) || throw(ArgumentError("each θ[i] must be in [0,1]"))

--- a/src/Tail/BC2Tail.jl
+++ b/src/Tail/BC2Tail.jl
@@ -47,7 +47,7 @@ struct BC2Tail{T} <: DiscreteSpectralPickandsTail
     function BC2Tail(a::AbstractVector)
         length(a) >= 2 || throw(ArgumentError("BC2Tail requires at least two coordinates",))
         vals = collect(a)
-        T = promote_type(Float64, eltype(vals))
+        T = float(eltype(vals))
         aa = T.(a)
         return new{T}(aa, DiscreteSpectralTail(hcat(aa, one(T) .- aa)))
     end

--- a/src/Tail/CuadrasAugeTail.jl
+++ b/src/Tail/CuadrasAugeTail.jl
@@ -104,9 +104,10 @@ function Distributions._rand!(rng::Distributions.AbstractRNG,
     kind === Π_LIMIT && return Random.rand!(rng, A)
     kind === M_LIMIT && return _rand_M!(rng, A)
 
-    θ = C.tail.θ
-    E = rand(rng, Distributions.Exponential(θ/(1-θ)), 2, size(A, 2))
-    E₁₂ = rand(rng, Distributions.Exponential(), size(A, 2))
+    R = promote_type(T, S)
+    θ = R(C.tail.θ)
+    E = rand(rng, Distributions.Exponential(θ / (one(R) - θ)), 2, size(A, 2))
+    E₁₂ = rand(rng, Distributions.Exponential(one(R)), size(A, 2))
     @inbounds for (j, col) in enumerate(axes(A, 2))
         A[1, col] = exp(-(1/θ) * min(E[1, j], E₁₂[j]))
         A[2, col] = exp(-(1/θ) * min(E[2, j], E₁₂[j]))

--- a/src/Tail/DiscreteSpectralTail.jl
+++ b/src/Tail/DiscreteSpectralTail.jl
@@ -23,7 +23,7 @@ struct DiscreteSpectralTail{T} <: DiscreteSpectralBackedTail
         m >= 1 || throw(ArgumentError("a discrete spectral tail requires at least one spectral atom",))
 
         vals = collect(B)
-        T = promote_type(Float64, map(typeof, vals)...)
+        T = float(promote_type(map(typeof, vals)...))
         BB = Matrix{T}(B)
 
         all(isfinite, BB) || throw(ArgumentError("all discrete spectral coefficients must be finite",))
@@ -95,12 +95,13 @@ end
 
 function _discrete_spectral_rand!(rng::Distributions.AbstractRNG, tail::DiscreteSpectralTail, X::AbstractMatrix{T},) where {T<:Real}
     d, n = size(X)
+    S = promote_type(T, eltype(tail))
     fill!(X, zero(T))
     m = size(tail.B, 2)
 
     @inbounds for col in 1:n
         for k in 1:m
-            invE = inv(Random.randexp(rng))
+            invE = inv(Random.randexp(rng, S))
             for i in 1:d
                 b = tail.B[i, k]
                 iszero(b) && continue

--- a/src/Tail/GalambosTail.jl
+++ b/src/Tail/GalambosTail.jl
@@ -153,7 +153,7 @@ function Distributions._rand!(rng::Distributions.AbstractRNG, C::ExtremeValueCop
 
     for col in axes(X, 2)
         fill!(z, zero(S))
-        arrival = S(Random.randexp(rng)) * invd
+        arrival = Random.randexp(rng, S) * invd
         radius = inv(arrival)
 
         while radius > minimum(z)
@@ -169,7 +169,7 @@ function Distributions._rand!(rng::Distributions.AbstractRNG, C::ExtremeValueCop
                 z[i] = max(z[i], radius * qi)
             end
 
-            arrival += S(Random.randexp(rng)) * invd
+            arrival += Random.randexp(rng, S) * invd
             radius = inv(arrival)
         end
 

--- a/src/Tail/MOTail.jl
+++ b/src/Tail/MOTail.jl
@@ -52,7 +52,7 @@ struct MOTail{T} <: DiscreteSpectralPickandsTail
         ))
 
         vals = collect(λ)
-        T = promote_type(Float64, eltype(vals))
+        T = float(eltype(vals))
         rates = T.(λ)
         all(isfinite, rates) || throw(ArgumentError("all Marshall-Olkin shock intensities must be finite",))
         all(v -> v >= zero(T), rates) || throw(ArgumentError("all Marshall-Olkin shock intensities must be nonnegative",))
@@ -136,11 +136,11 @@ end
 
 function Distributions._rand!(rng::Distributions.AbstractRNG, C::ExtremeValueCopula{2,<:MOTail}, A::AbstractMatrix{S}) where {S<:Real}
     λ₁, λ₂, λ₁₂ = _mo_bivariate_rates(C.tail)
-    T = promote_type(typeof(float(λ₁)), typeof(float(λ₂)), typeof(float(λ₁₂)))
+    T = promote_type(S, typeof(float(λ₁)), typeof(float(λ₂)), typeof(float(λ₁₂)))
     λ₁T, λ₂T, λ₁₂T = T(λ₁), T(λ₂), T(λ₁₂)
     rate_u, rate_v = λ₂T + λ₁₂T, λ₁T + λ₁₂T
     (rate_u > 0 && rate_v > 0) || throw(ArgumentError("Each Marshall-Olkin margin must have a positive total rate"))
-    waiting_time(rate) = iszero(rate) ? T(Inf) : T(Random.randexp(rng)) / rate
+    waiting_time(rate) = iszero(rate) ? T(Inf) : Random.randexp(rng, T) / rate
 
     # The first Pickands coordinate used by A is -log(u), so its private
     # shock has rate λ₂; the second coordinate analogously uses rate λ₁.

--- a/src/Tail/MixedTail.jl
+++ b/src/Tail/MixedTail.jl
@@ -111,26 +111,27 @@ function Distributions._rand!(rng::Distributions.AbstractRNG, C::ExtremeValueCop
     limit_kind(C.tail, Val(d)) === Π_LIMIT && return Random.rand!(rng, X)
     n = size(X, 2)
 
-    θ = Float64(C.tail.θ)
-    Z = zeros(Float64, d, n)
+    S = promote_type(T, typeof(C.tail.θ))
+    θ = S(C.tail.θ)
+    Z = zeros(S, d, n)
 
     # Independent max-stable component with exponent
     # (1-θ) Σᵢ xᵢ.
     if θ < 1
         w = 1 - θ
         @inbounds for i in 1:d, col in 1:n
-            Z[i, col] = w / Random.randexp(rng)
+            Z[i, col] = w / Random.randexp(rng, S)
         end
     end
 
     # Galambos(1) max-stable component with exponent
     # θ ℓ_Galambos,1.
     if θ > 0
-        Cgal = ExtremeValueCopula(d, GalambosTail(1.0))
+        Cgal = ExtremeValueCopula(d, GalambosTail(one(S)))
         U = Random.rand(rng, Cgal, n)
 
         @inbounds for i in 1:d, col in 1:n
-            candidate = θ / (-log(Float64(U[i, col])))
+            candidate = θ / (-log(U[i, col]))
             if candidate > Z[i, col]
                 Z[i, col] = candidate
             end

--- a/src/Tail/utilities.jl
+++ b/src/Tail/utilities.jl
@@ -26,12 +26,11 @@ function _normalize_asymmetric_subset_components(
         "each asymmetry component must be an AbstractVector",
     ))
 
-    T = promote_type(
-        Float64,
+    T = float(promote_type(
         typeof(singleton_parameter),
         eltype(dep),
         _component_eltype(eltype(asy)),
-    )
+    ))
 
     parameters = fill(T(singleton_parameter), m)
     @inbounds for j in (d + 1):m
@@ -73,7 +72,7 @@ end
 function _expand_fullset_asymmetric_component(parameter::Real, weights::AbstractVector; singleton_parameter)
     d = length(weights)
     subsets = d == 0 ? Vector{Vector{Int}}() : _nonempty_subsets(d)
-    T = promote_type(Float64, typeof(parameter), typeof(singleton_parameter), eltype(weights))
+    T = float(promote_type(typeof(parameter), typeof(singleton_parameter), eltype(weights)))
     w = T.(weights)
 
     dep = fill(T(singleton_parameter), length(subsets) - d)
@@ -109,7 +108,8 @@ function _rand_subset_components!(
 ) where {T<:Real}
     d, n = size(X)
     subsets = _nonempty_subsets(d)
-    Z = zeros(Float64, d, n)
+    S = promote_type(T, eltype(parameters), eltype(β))
+    Z = zeros(S, d, n)
 
     @inbounds for j in eachindex(subsets)
         active = [i for i in subsets[j] if β[i, j] > 0]
@@ -117,14 +117,14 @@ function _rand_subset_components!(
         parameter = parameters[j]
         if is_independent(parameter) || length(active) == 1
             for i in active, col in 1:n
-                Z[i, col] = max(Z[i, col], Float64(β[i, j]) / Random.randexp(rng))
+                Z[i, col] = max(Z[i, col], S(β[i, j]) / Random.randexp(rng, S))
             end
             continue
         end
 
         U = rand(rng, component_copula(length(active), parameter), n)
         for (position, i) in enumerate(active), col in 1:n
-            candidate = Float64(β[i, j]) / (-log(Float64(U[position, col])))
+            candidate = S(β[i, j]) / (-log(S(U[position, col])))
             Z[i, col] = max(Z[i, col], candidate)
         end
     end

--- a/src/UnivariateDistribution/ExtremeDist.jl
+++ b/src/UnivariateDistribution/ExtremeDist.jl
@@ -1,6 +1,7 @@
 struct ExtremeDist{C} <: Distributions.ContinuousUnivariateDistribution
     tail::C
 end
+Base.eltype(d::ExtremeDist) = eltype(d.tail)
 
 Base.minimum(::ExtremeDist) = 0
 Base.maximum(::ExtremeDist) = 1
@@ -28,4 +29,5 @@ function Distributions.quantile(d::ExtremeDist, p)
 end
 
 # Generate random samples from the radial distribution using the quantile function
-Distributions.rand(rng::Distributions.AbstractRNG, d::ExtremeDist) = Distributions.quantile(d, rand(rng))
+Distributions.rand(rng::Distributions.AbstractRNG, d::ExtremeDist) =
+    Distributions.quantile(d, rand(rng, eltype(d)))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -393,8 +393,17 @@ end
 _parameter_eltype(::Integer) = Union{}
 _parameter_eltype(::Bool) = Union{}
 _parameter_eltype(x::Real) = typeof(float(x))
-_parameter_eltype(x::AbstractArray) = float(eltype(x))
-_parameter_eltype(x::Distributions.Distribution) = float(eltype(x))
+_parameter_eltype(x::AbstractArray{<:Real}) = float(eltype(x))
+function _parameter_eltype(x::AbstractArray)
+    T = Union{}
+    for value in x
+        S = _parameter_eltype(value)
+        S === Union{} && continue
+        T = T === Union{} ? S : promote_type(T, S)
+    end
+    return T
+end
+_parameter_eltype(x::Distributions.Distribution) = float(Distributions.partype(x))
 _parameter_eltype(x::NamedTuple) = _parameter_eltype(values(x))
 _parameter_eltype(x::Tuple) = _parameter_eltype(x...)
 _parameter_eltype() = Union{}

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -158,7 +158,8 @@ different tie convention is required.
 function pseudos(sample::AbstractMatrix)
     # Fast pseudo-observations (d×n) using per-row ordinal ranks without allocations per row
     d, n = size(sample)
-    U = Matrix{Float64}(undef, d, n)
+    T = float(eltype(sample))
+    U = Matrix{T}(undef, d, n)
     tmp_idx = Vector{Int}(undef, n)
     @inbounds for i in 1:d
         # compute ordinal ranks for row i
@@ -167,7 +168,7 @@ function pseudos(sample::AbstractMatrix)
         sortperm!(tmp_idx, x; by=identity, alg=Base.Sort.DEFAULT_STABLE)
         # ranks: position in sorted order; ties preserve order of appearance
         for (rank, idx) in enumerate(tmp_idx)
-            U[i, idx] = rank / (n + 1)
+            U[i, idx] = T(rank) / T(n + 1)
         end
     end
     return U
@@ -385,4 +386,27 @@ function _kendall_sample(u::AbstractMatrix)
         W[i] = count_le / (n + 1)
     end
     return W
+end
+# Numeric type carried by a parameter object. Integer and Boolean values are
+# structural unless they occur in an array whose element type is the actual
+# stored numeric representation.
+_parameter_eltype(::Integer) = Union{}
+_parameter_eltype(::Bool) = Union{}
+_parameter_eltype(x::Real) = typeof(float(x))
+_parameter_eltype(x::AbstractArray) = float(eltype(x))
+_parameter_eltype(x::Distributions.Distribution) = float(eltype(x))
+_parameter_eltype(x::NamedTuple) = _parameter_eltype(values(x))
+_parameter_eltype(x::Tuple) = _parameter_eltype(x...)
+_parameter_eltype() = Union{}
+function _parameter_eltype(x, xs...)
+    T = _parameter_eltype(x)
+    S = _parameter_eltype(xs...)
+    T === Union{} && return S
+    S === Union{} && return T
+    return promote_type(T, S)
+end
+_parameter_eltype(x) = _parameter_eltype(Distributions.params(x))
+function _sample_eltype(x)
+    T = _parameter_eltype(x)
+    return T === Union{} ? Float64 : T
 end

--- a/test/api/utilities.jl
+++ b/test/api/utilities.jl
@@ -6,6 +6,7 @@
     @test size(U) == size(X)
     @test all(x -> 0 < x < 1, U)
     @test pseudos(U) == U
+    @test eltype(pseudos(Float32.(X))) === Float32
 
     target = [1.0 0.4; 0.4 1.0]
     @test Nataf((Normal(), Normal(2, 3)), target) == target

--- a/test/operations/sampling.jl
+++ b/test/operations/sampling.jl
@@ -94,6 +94,7 @@ end
     )
     for (C, T) in cases
         @test eltype(C) === T
+        @test partype(C) === T
         @test eltype(rand(StableRNG(61), C)) === T
         @test eltype(rand(StableRNG(62), C, 2)) === T
     end
@@ -106,6 +107,7 @@ end
     )
     for C in big_cases
         @test eltype(C) === BigFloat
+        @test partype(C) === BigFloat
         @test eltype(rand(StableRNG(65), C, 2)) === BigFloat
     end
 
@@ -115,6 +117,7 @@ end
                   (Normal(Float32(0), Float32(1)),
                    Exponential(Float32(1))))
     @test eltype(S) === Float32
+    @test partype(S) === Float64
     @test eltype(rand(StableRNG(63), S)) === Float32
     @test eltype(rand(StableRNG(64), S, 2)) === Float32
 end

--- a/test/operations/sampling.jl
+++ b/test/operations/sampling.jl
@@ -61,3 +61,49 @@ end
     @test all(isnan, storage[[1, 5], :])
     @test_throws DimensionMismatch rand!(StableRNG(52), C, zeros(Float32, 2, 1))
 end
+
+@testset "default sample element types" begin
+    Carch = ClaytonCopula{2}(Float32(1))
+    Cev = GalambosCopula{2}(Float32(1))
+    Cell = GaussianCopula{2}(Float32(0.3))
+    Cliouville = LiouvilleCopula{2}(
+        Copulas.ClaytonGenerator(Float32(1)), (Float32(1), Float32(2)))
+    Carchimax = ArchimaxCopula{2}(
+        Copulas.ClaytonGenerator(Float32(1)),
+        Copulas.GalambosTail(Float64(1)),
+    )
+    Cstudent = TCopula{2}(
+        Float32(4), Float32[1 0.3; 0.3 1])
+    Cempirical = EmpiricalCopula{2}(
+        Float32[0.2 0.4 0.6 0.8; 0.8 0.6 0.4 0.2])
+
+    cases = (
+        Carch => Float32,
+        Cev => Float32,
+        Cell => Float32,
+        Cstudent => Float32,
+        FGMCopula{2}(Float32(0.5)) => Float32,
+        PlackettCopula{2}(Float32(2)) => Float32,
+        RafteryCopula{2}(Float32(0.5)) => Float32,
+        Cempirical => Float32,
+        Cliouville => Float32,
+        SurvivalCopula(Carch, (1,)) => Float32,
+        subsetdims(ClaytonCopula{3}(Float32(1)), (1, 2)) => Float32,
+        Carchimax => Float64,
+        IndependentCopula{2}() => Float64,
+    )
+    for (C, T) in cases
+        @test eltype(C) === T
+        @test eltype(rand(StableRNG(61), C)) === T
+        @test eltype(rand(StableRNG(62), C, 2)) === T
+    end
+
+    # A Sklar distribution samples on its marginal scales. The copula's
+    # probability representation therefore must not widen Float32 margins.
+    S = SklarDist(IndependentCopula{2}(),
+                  (Normal(Float32(0), Float32(1)),
+                   Exponential(Float32(1))))
+    @test eltype(S) === Float32
+    @test eltype(rand(StableRNG(63), S)) === Float32
+    @test eltype(rand(StableRNG(64), S, 2)) === Float32
+end

--- a/test/operations/sampling.jl
+++ b/test/operations/sampling.jl
@@ -98,6 +98,17 @@ end
         @test eltype(rand(StableRNG(62), C, 2)) === T
     end
 
+    big_cases = (
+        ClaytonCopula{2}(big"1.0"),
+        ClaytonCopula{2}(big"0.0"),
+        GalambosCopula{2}(big"1.0"),
+        PlackettCopula{2}(big"2.0"),
+    )
+    for C in big_cases
+        @test eltype(C) === BigFloat
+        @test eltype(rand(StableRNG(65), C, 2)) === BigFloat
+    end
+
     # A Sklar distribution samples on its marginal scales. The copula's
     # probability representation therefore must not widen Float32 margins.
     S = SklarDist(IndependentCopula{2}(),


### PR DESCRIPTION
Closes #195.\n\nAligns copula sampling with the Distributions.jl eltype contract, propagates numeric types through compositions and wrappers, and derives SklarDist samples from their marginal types. Adds Float32 and in-place sampling coverage.\n\nA follow-up commit on this branch is auditing genuine BigFloat random primitives rather than only BigFloat output allocation.