### PR TITLE
Make pseudo-observation tie handling explicit and order-invariant

### DIFF
--- a/docs/src/bestiary/empirical.md
+++ b/docs/src/bestiary/empirical.md
@@ -11,16 +11,23 @@ Through the statistical process leading to the estimation of copulas, one usuall
 
 ::: definition Pseudo-observations
 
-If $\boldsymbol x \in \mathbb{R}^{N \times d}$ is an $N$-sample of a $d$-variate real-valued random vector $\boldsymbol X$, then the pseudo-observations are the normalized ranks of the marginals of $\boldsymbol x$, defined as:
+If $\boldsymbol x \in \mathbb{R}^{N \times d}$ is an $N$-sample of a $d$-variate real-valued random vector $\boldsymbol X$, then the pseudo-observations are the normalized ranks of the marginals of $\boldsymbol x$, defined in the absence of ties as:
 
 $$\boldsymbol u \in [0,1]^{N \times d}:\; u_{i,j} = \frac{\mathrm{Rank}(x_{i,j}, \boldsymbol x_{\cdot,j})}{N+1} = \frac{1}{N+1} \sum_{k=1}^N \mathbb{1}_{x_{k,j} \le x_{i,j}},$$
 
 where $\mathrm{Rank}(y, \boldsymbol x) = \sum_{x_i \in \boldsymbol x} \mathbb{1}_{x_i \le y}$.
 
+With tied observations, the rank convention becomes part of the estimator.
+`pseudos` uses average ranks by default, matching the usual R and vinecopulib
+convention. The `ties` keyword also provides `:first`, `:last`, `:min`, `:max`,
+and `:random`; the latter accepts an explicit `rng` for reproducibility. These
+choices agree when margins are tie-free. A tie convention does not, on its own,
+make inference designed for continuous margins valid for discrete data.
+
 :::
 
 
-In `Copulas.jl`, we provide a function `pseudos` that implement this transformation directly. 
+In `Copulas.jl`, the function `pseudos` implements this transformation directly.
 
 See the canonical Public API entry for [`pseudos`](@ref).
 

--- a/docs/src/manual/hypothesis_testing.md
+++ b/docs/src/manual/hypothesis_testing.md
@@ -63,7 +63,7 @@ to avoid ranking them again.
 
 The currently implemented copula hypothesis tests assume continuous margins and therefore require tie-free observations in every margin. Tied or discrete data are rejected with an `ArgumentError`.
 
-This is intentional: ordinal ranking would otherwise assign distinct ranks to tied observations and could produce apparently valid p-values without the tie-aware empirical-process or bootstrap theory required for such data. Tie-aware procedures are outside the scope of the current implementation.
+This is intentional: choosing a rank convention would otherwise produce apparently valid p-values without the tie-aware empirical-process or bootstrap theory required for such data. Although [`pseudos`](@ref) uses average ranks by default, that convention alone does not make continuous-margin tests valid for discrete or rounded data. Tie-aware procedures are outside the scope of the current implementation.
 
 :::
 

--- a/src/CopulaTest.jl
+++ b/src/CopulaTest.jl
@@ -594,15 +594,7 @@ function _randomization_sample(::RadialSymmetryHypothesis, U::AbstractMatrix, rn
 end
 
 function _average_pseudos(sample::AbstractMatrix)
-    d, n = size(sample)
-    U = Matrix{Float64}(undef, d, n)
-    denom = n + 1
-
-    @inbounds for j in 1:d
-        U[j, :] .= StatsBase.tiedrank(@view sample[j, :]) ./ denom
-    end
-
-    return U
+    return Matrix{Float64}(pseudos(sample; ties=:average))
 end
 
 _randomization_pseudos(::RadialSymmetryHypothesis, sample::AbstractMatrix,) = _average_pseudos(sample)

--- a/src/Fitting.jl
+++ b/src/Fitting.jl
@@ -442,6 +442,8 @@ function Distributions.fit(::Type{CopulaModel}, ::Type{SklarDist{CT,TplMargins}}
             U[i, j] = clamp(Distributions.cdf(m[i], X[i, j]), lower, upper)
         end
     else # :ecdf then
+        # Average ranks are the public default. Continuous-data inference still
+        # requires users to assess whether ties represent rounding or discreteness.
         U .= pseudos(X)
     end
 

--- a/src/MiscellaneousCopulas/BernsteinCopula.jl
+++ b/src/MiscellaneousCopulas/BernsteinCopula.jl
@@ -17,6 +17,10 @@ Behavior and cost:
   approximation but require work and memory proportional to ``\\prod_j m_j``.
   Large `d` or `m` can therefore be prohibitive.
 - If ``C`` is an `EmpiricalCopula`, the constructor produces the *empirical Bernstein copula*, a smoothed version of the empirical copula.
+- Raw data supplied with `pseudo_values=false` must have tie-free margins.
+  Resolve ties explicitly with `pseudos(data; ties=:first)`, `:last`, or
+  `:random` before construction when deliberate tie breaking is scientifically
+  justified.
 - Supports `cdf`, `logpdf`, and random generation via mixtures of beta distributions.
 
 See also: [`BetaCopula`](@ref), [`EmpiricalCopula`](@ref), [`Copula`](@ref),
@@ -68,7 +72,9 @@ BernsteinCopula(base::Copula{d}; kwargs...) where {d} = BernsteinCopula{d}(base;
 BernsteinCopula(d::Integer, base::Copula; kwargs...) = BernsteinCopula{d}(base; kwargs...)
 function BernsteinCopula{d}(data::AbstractMatrix; kwargs...) where {d}
     size(data, 1) == d || throw(DimensionMismatch("data must have $d rows"))
-    return BernsteinCopula{d}(EmpiricalCopula{d}(data; pseudo_values=get(kwargs, :pseudo_values, true));
+    pseudo_values = get(kwargs, :pseudo_values, true)
+    pseudo_values || _require_tie_free_rows(data, "BernsteinCopula")
+    return BernsteinCopula{d}(EmpiricalCopula{d}(data; pseudo_values=pseudo_values);
                               m=get(kwargs, :m, nothing))
 end
 BernsteinCopula(data::AbstractMatrix; kwargs...) = BernsteinCopula{size(data, 1)}(data; kwargs...)

--- a/src/MiscellaneousCopulas/BetaCopula.jl
+++ b/src/MiscellaneousCopulas/BetaCopula.jl
@@ -1,7 +1,7 @@
 """
-    BetaCopula(u)
-    BetaCopula{d}(u)
-    BetaCopula(d, u)
+    BetaCopula(data)
+    BetaCopula{d}(data)
+    BetaCopula(d, data)
     
 The empirical beta copula in dimension ``d`` is defined as
 
@@ -13,8 +13,11 @@ where ``R_{ij}`` is the rank of observation ``i`` in margin ``j``, and ``U \\sim
 
 Notes:
 - This is always a valid copula for any finite sample size `n`.
-- Rows of `u` are variables and columns are observations. Each row is ranked
-  internally using ordinal ranks, so ties are broken by their input order.
+- Rows of `data` are variables and columns are observations. Empirical beta
+  copulas require each margin to have distinct ranks; tied margins are rejected
+  rather than broken according to observation order. If deliberate tie breaking
+  is appropriate, apply [`pseudos`](@ref) with `ties=:first`, `:last`, or
+  `:random` first. Tie-preserving methods remain tied and are still rejected.
 - The beta kernels smooth the empirical mass into an absolutely continuous
   copula. This removes atoms but does not remove finite-sample uncertainty or
   sensitivity to the tie convention.
@@ -31,6 +34,7 @@ struct BetaCopula{d,MT} <: Copula{d}
     n::Int
     function BetaCopula{d}(data::AbstractMatrix) where {d}
         size(data, 1) == d || throw(DimensionMismatch("data must have $d rows"))
+        _require_tie_free_rows(data, "BetaCopula")
         n = size(data, 2)
         R = Matrix{Int}(undef, d, n)
         @inbounds for j in 1:d

--- a/src/MiscellaneousCopulas/CheckerboardCopula.jl
+++ b/src/MiscellaneousCopulas/CheckerboardCopula.jl
@@ -21,7 +21,10 @@ Notes:
 - If `m` is `nothing`, we use `m = fill(n, d)` where `n = size(X, 2)`.
 - When `pseudo_values=true` (default), `X` must already be pseudo-observations
   in [0,1]. Otherwise pass raw data and set `pseudo_values=false` to convert
-  via `pseudos(X)`.
+  via `pseudos(X)`. Raw tied margins are rejected because silently breaking
+  them can change the fitted dependence according to observation order; resolve
+  them explicitly with `pseudos(X; ties=:first)`, `:last`, or `:random` when
+  deliberate tie breaking is scientifically justified.
 - Each `m[i]` must divide `n` to produce a valid checkerboard on the sample grid;
   this is enforced by the constructor.
 
@@ -47,6 +50,7 @@ end
 Base.eltype(::CheckerboardCopula{d,T}) where {d,T} = T
 function CheckerboardCopula{d}(X::AbstractMatrix{T}; m=nothing, pseudo_values::Bool=true) where {d,T}
     size(X, 1) == d || throw(DimensionMismatch("data must have $d rows"))
+    pseudo_values || _require_tie_free_rows(X, "CheckerboardCopula")
     n = size(X, 2)
      ms = if isnothing(m)
         @info "Automatic choice: m = n in each dimension." d=d n=n

--- a/src/MiscellaneousCopulas/EmpiricalCopula.jl
+++ b/src/MiscellaneousCopulas/EmpiricalCopula.jl
@@ -11,7 +11,11 @@ Its distribution function is
 C(\\mathbf{x}) = \\frac{1}{N} \\sum_{j=1}^{N} \\mathbf{1}_{\\{ \\mathbf{u}_{\\cdot,j} \\le \\mathbf{x} \\}} ,
 ```
 
-where the inequality is componentwise. If `pseudo_values=false`, the constructor first ranks the raw data into pseudo-observations; otherwise it assumes `u` already contains pseudo-observations in ``[0,1]``.
+where the inequality is componentwise. If `pseudo_values=false`, the constructor
+first ranks the raw data into pseudo-observations using the default average-rank
+tie convention; otherwise it assumes `u` already contains pseudo-observations in
+``[0,1]``. Call `pseudos(data; ties=...)` explicitly before construction to use
+another convention.
 
 Notes:
 - This is an empirical distribution on the observed pseudo-points. For finite

--- a/src/Tail/EmpiricalEVTail.jl
+++ b/src/Tail/EmpiricalEVTail.jl
@@ -39,10 +39,11 @@ Construct the empirical Pickands tail from data (2×N).
 
 Rows of `u` are the two margins and columns are observations. With
 `pseudo_values=true`, values are interpreted as pseudo-observations; otherwise
-the margins are ranked first. `method` selects the classical Pickands, CFG, or
-OLS-intercept pilot estimator. The pilot is evaluated on `grid` points between
-`eps` and `1-eps`, then projected onto the convex Pickands class and extended
-with the required endpoint values.
+the margins are ranked first using the default average-rank tie convention.
+Call `pseudos(data; ties=...)` explicitly to use another convention. `method`
+selects the classical Pickands, CFG, or OLS-intercept pilot estimator. The pilot
+is evaluated on `grid` points between `eps` and `1-eps`, then projected onto the
+convex Pickands class and extended with the required endpoint values.
 
 The returned tail evaluates `A` by piecewise-linear interpolation. Increasing
 `grid` gives a finer representation at additional fitting and storage cost;

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -161,19 +161,25 @@ end
 
 
 """
-    pseudos(sample)
+    pseudos(sample; ties=:average, rng=Random.default_rng())
 
 Compute pseudo-observations from a `d×n` sample, with variables in rows and
 observations in columns.
 
-Each row is replaced by its ordinal ranks divided by `n+1`, so every output is
-strictly inside `(0,1)`. The transformation is invariant under strictly
-increasing changes of each margin and returns a newly allocated floating-point
-matrix.
+Each row is replaced by its ranks divided by `n+1`, so every output is strictly
+inside `(0,1)`. The transformation is invariant under strictly increasing
+changes of each margin and returns a newly allocated floating-point matrix.
 
-Ties are resolved by stable ordinal ranking, so tied values receive distinct
-ranks in their order of appearance. Use a dedicated rank transformation when a
-different tie convention is required.
+The `ties` keyword controls equal observations. Supported values are `:average`
+(the default), `:first`, `:last`, `:min`, `:max`, and `:random`. Average ranks
+preserve ties and make the result invariant to observation order. `:first` is
+the ordinal convention used by Copulas.jl before version 1.0; `:last` reverses
+that order within each tied group. `:random` randomly assigns the available
+ordinal ranks within each tied group and uses `rng`; deterministic methods do
+not consume it.
+
+Choosing a rank convention does not by itself make continuous-margin fitting
+or hypothesis-testing procedures valid for genuinely discrete data.
 
 # Example
 ```julia
@@ -184,21 +190,70 @@ pseudos(X) == [0.75 0.25 0.5; 0.25 0.75 0.5]
 See also: [`EmpiricalCopula`](@ref), [`BetaCopula`](@ref),
 [`CheckerboardCopula`](@ref).
 """
-function pseudos(sample::AbstractMatrix)
-    # Fast pseudo-observations (d×n) using per-row ordinal ranks without allocations per row
+const _PSEUDO_TIE_METHODS = (:average, :first, :last, :min, :max, :random)
+
+function _pseudoranks!(ranks::AbstractVector{T}, x::AbstractVector, ties::Symbol,
+        rng::Random.AbstractRNG, order::Vector{Int}) where {T<:AbstractFloat}
+    ties in _PSEUDO_TIE_METHODS || throw(ArgumentError(
+        "unsupported tie method :$ties; expected one of $(_PSEUDO_TIE_METHODS)"))
+    sortperm!(order, x; by=identity, alg=Base.Sort.DEFAULT_STABLE)
+
+    if ties === :first
+        @inbounds for (rank, index) in enumerate(order)
+            ranks[index] = T(rank)
+        end
+        return ranks
+    end
+
+    n = length(order)
+    first = 1
+    while first <= n
+        last = first
+        @inbounds while last < n && x[order[last + 1]] == x[order[first]]
+            last += 1
+        end
+
+        if ties === :average
+            rank = (T(first) + T(last)) / T(2)
+            @inbounds for k in first:last
+                ranks[order[k]] = rank
+            end
+        elseif ties === :min
+            @inbounds for k in first:last
+                ranks[order[k]] = T(first)
+            end
+        elseif ties === :max
+            @inbounds for k in first:last
+                ranks[order[k]] = T(last)
+            end
+        elseif ties === :last
+            @inbounds for k in first:last
+                ranks[order[k]] = T(last - (k - first))
+            end
+        else # :random
+            Random.shuffle!(rng, @view order[first:last])
+            @inbounds for k in first:last
+                ranks[order[k]] = T(k)
+            end
+        end
+        first = last + 1
+    end
+    return ranks
+end
+
+function pseudos(sample::AbstractMatrix; ties::Symbol=:average,
+        rng::Random.AbstractRNG=Random.default_rng())
+    ties in _PSEUDO_TIE_METHODS || throw(ArgumentError(
+        "unsupported tie method :$ties; expected one of $(_PSEUDO_TIE_METHODS)"))
     d, n = size(sample)
     T = float(eltype(sample))
     U = Matrix{T}(undef, d, n)
     tmp_idx = Vector{Int}(undef, n)
     @inbounds for i in 1:d
-        # compute ordinal ranks for row i
         x = @view sample[i, :]
-        # sortperm is stable; ordinal ranks from positions in sorted order
-        sortperm!(tmp_idx, x; by=identity, alg=Base.Sort.DEFAULT_STABLE)
-        # ranks: position in sorted order; ties preserve order of appearance
-        for (rank, idx) in enumerate(tmp_idx)
-            U[i, idx] = T(rank) / T(n + 1)
-        end
+        ranks = @view U[i, :]
+        _pseudoranks!(ranks, x, ties, rng, tmp_idx)
+        ranks ./= T(n + 1)
     end
     return U
 end
@@ -459,16 +514,14 @@ where `C_n` is the Deheuvels empirical copula built from the same `u`.
 
 Input and tie handling
 - `u` is expected as a `d×n` matrix (columns are observations). This routine first
-    applies per-margin ordinal ranks (same policy as `pseudos`) so that the result is
-    invariant under strictly increasing marginal transformations and robust to ties.
-    Consequently, `_kendall_sample(u) ≡ _kendall_sample(pseudos(u))` (same tie policy).
+  applies per-margin ordinal ranks (the pre-1.0 `pseudos` policy) so that the
+  result is invariant under strictly increasing marginal transformations.
 
 Returns
 - `Vector{Float64}` of length `n` with values in `(0,1)`.
 """
 function _kendall_sample(u::AbstractMatrix)
     d, n = size(u)
-    # Apply ordinal ranks per margin to remove ties consistently with `pseudos`
     R = Matrix{Int}(undef, d, n)
     @inbounds for i in 1:d
         R[i, :] = StatsBase.ordinalrank(@view u[i, :])

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -207,7 +207,6 @@ function _pseudos(sample::AbstractMatrix, tie_method::Val,
         x = @view sample[i, :]
         ranks = @view U[i, :]
         _pseudoranks!(ranks, x, tie_method, rng, tmp_idx)
-        ranks ./= T(n + 1)
     end
     return U
 end
@@ -225,8 +224,9 @@ end
 
 function _assign_pseudoranks!(ranks::AbstractVector{T}, ::AbstractVector,
         order::Vector{Int}, ::Val{:first}, ::Random.AbstractRNG) where {T}
+    scale = inv(T(length(order) + 1))
     @inbounds for (rank, index) in enumerate(order)
-        ranks[index] = T(rank)
+        ranks[index] = T(rank) * scale
     end
     return ranks
 end
@@ -235,21 +235,23 @@ function _assign_pseudoranks!(ranks::AbstractVector, x::AbstractVector,
         order::Vector{Int}, tie_method::_GROUPED_PSEUDO_TIE_METHOD,
         rng::Random.AbstractRNG)
     n = length(order)
+    scale = inv(eltype(ranks)(n + 1))
     first = 1
     while first <= n
         last = first
         @inbounds while last < n && x[order[last + 1]] == x[order[first]]
             last += 1
         end
-        _assign_tie_group!(ranks, order, first, last, tie_method, rng)
+        _assign_tie_group!(ranks, order, first, last, scale, tie_method, rng)
         first = last + 1
     end
     return ranks
 end
 
 function _assign_tie_group!(ranks::AbstractVector{T}, order::Vector{Int},
-        first::Int, last::Int, ::Val{:average}, ::Random.AbstractRNG) where {T}
-    rank = (T(first) + T(last)) / T(2)
+        first::Int, last::Int, scale::T, ::Val{:average},
+        ::Random.AbstractRNG) where {T}
+    rank = ((T(first) + T(last)) / T(2)) * scale
     @inbounds for k in first:last
         ranks[order[k]] = rank
     end
@@ -257,34 +259,40 @@ function _assign_tie_group!(ranks::AbstractVector{T}, order::Vector{Int},
 end
 
 function _assign_tie_group!(ranks::AbstractVector{T}, order::Vector{Int},
-        first::Int, last::Int, ::Val{:min}, ::Random.AbstractRNG) where {T}
+        first::Int, last::Int, scale::T, ::Val{:min},
+        ::Random.AbstractRNG) where {T}
+    rank = T(first) * scale
     @inbounds for k in first:last
-        ranks[order[k]] = T(first)
+        ranks[order[k]] = rank
     end
     return nothing
 end
 
 function _assign_tie_group!(ranks::AbstractVector{T}, order::Vector{Int},
-        first::Int, last::Int, ::Val{:max}, ::Random.AbstractRNG) where {T}
+        first::Int, last::Int, scale::T, ::Val{:max},
+        ::Random.AbstractRNG) where {T}
+    rank = T(last) * scale
     @inbounds for k in first:last
-        ranks[order[k]] = T(last)
+        ranks[order[k]] = rank
     end
     return nothing
 end
 
 function _assign_tie_group!(ranks::AbstractVector{T}, order::Vector{Int},
-        first::Int, last::Int, ::Val{:last}, ::Random.AbstractRNG) where {T}
+        first::Int, last::Int, scale::T, ::Val{:last},
+        ::Random.AbstractRNG) where {T}
     @inbounds for k in first:last
-        ranks[order[k]] = T(last - (k - first))
+        ranks[order[k]] = T(last - (k - first)) * scale
     end
     return nothing
 end
 
 function _assign_tie_group!(ranks::AbstractVector{T}, order::Vector{Int},
-        first::Int, last::Int, ::Val{:random}, rng::Random.AbstractRNG) where {T}
+        first::Int, last::Int, scale::T, ::Val{:random},
+        rng::Random.AbstractRNG) where {T}
     Random.shuffle!(rng, @view order[first:last])
     @inbounds for k in first:last
-        ranks[order[k]] = T(k)
+        ranks[order[k]] = T(k) * scale
     end
     return nothing
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -213,6 +213,9 @@ function _pseudos(sample::AbstractMatrix, tie_method::Val,
 end
 
 const _PSEUDO_TIE_METHODS = (:average, :first, :last, :min, :max, :random)
+const _GROUPED_PSEUDO_TIE_METHOD = Union{
+    Val{:average}, Val{:last}, Val{:min}, Val{:max}, Val{:random},
+}
 
 function _pseudoranks!(ranks::AbstractVector, x::AbstractVector, tie_method::Val,
         rng::Random.AbstractRNG, order::Vector{Int})
@@ -228,8 +231,9 @@ function _assign_pseudoranks!(ranks::AbstractVector{T}, ::AbstractVector,
     return ranks
 end
 
-function _assign_tied_pseudoranks!(ranks::AbstractVector, x::AbstractVector,
-        order::Vector{Int}, tie_method::Val, rng::Random.AbstractRNG)
+function _assign_pseudoranks!(ranks::AbstractVector, x::AbstractVector,
+        order::Vector{Int}, tie_method::_GROUPED_PSEUDO_TIE_METHOD,
+        rng::Random.AbstractRNG)
     n = length(order)
     first = 1
     while first <= n
@@ -241,31 +245,6 @@ function _assign_tied_pseudoranks!(ranks::AbstractVector, x::AbstractVector,
         first = last + 1
     end
     return ranks
-end
-
-function _assign_pseudoranks!(ranks::AbstractVector, x::AbstractVector,
-        order::Vector{Int}, tie_method::Val{:average}, rng::Random.AbstractRNG)
-    return _assign_tied_pseudoranks!(ranks, x, order, tie_method, rng)
-end
-
-function _assign_pseudoranks!(ranks::AbstractVector, x::AbstractVector,
-        order::Vector{Int}, tie_method::Val{:last}, rng::Random.AbstractRNG)
-    return _assign_tied_pseudoranks!(ranks, x, order, tie_method, rng)
-end
-
-function _assign_pseudoranks!(ranks::AbstractVector, x::AbstractVector,
-        order::Vector{Int}, tie_method::Val{:min}, rng::Random.AbstractRNG)
-    return _assign_tied_pseudoranks!(ranks, x, order, tie_method, rng)
-end
-
-function _assign_pseudoranks!(ranks::AbstractVector, x::AbstractVector,
-        order::Vector{Int}, tie_method::Val{:max}, rng::Random.AbstractRNG)
-    return _assign_tied_pseudoranks!(ranks, x, order, tie_method, rng)
-end
-
-function _assign_pseudoranks!(ranks::AbstractVector, x::AbstractVector,
-        order::Vector{Int}, tie_method::Val{:random}, rng::Random.AbstractRNG)
-    return _assign_tied_pseudoranks!(ranks, x, order, tie_method, rng)
 end
 
 function _assign_tie_group!(ranks::AbstractVector{T}, order::Vector{Int},

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -258,6 +258,16 @@ function pseudos(sample::AbstractMatrix; ties::Symbol=:average,
     return U
 end
 
+function _require_tie_free_rows(sample::AbstractMatrix, operation::AbstractString)
+    for row in axes(sample, 1)
+        allunique(@view sample[row, :]) || throw(ArgumentError(
+            "$operation requires tie-free margins; ties were detected in margin $row. " *
+            "If deliberate tie breaking is justified, preprocess the data with pseudos " *
+            "using :first, :last, or :random before construction."))
+    end
+    return nothing
+end
+
 # Pairwise component metrics applied to (n,d)-shaped matrices:
 """
     corblomqvist(X::AbstractMatrix)
@@ -513,25 +523,25 @@ Compute the empirical Kendall sample `W` with entries `W[i] = C_n(U[:,i])`,
 where `C_n` is the Deheuvels empirical copula built from the same `u`.
 
 Input and tie handling
-- `u` is expected as a `d×n` matrix (columns are observations). This routine first
-  applies per-margin ordinal ranks (the pre-1.0 `pseudos` policy) so that the
-  result is invariant under strictly increasing marginal transformations.
+- `u` is expected as a `d×n` matrix (columns are observations).
+- Dominance is evaluated directly on `u`, preserving equal values. The result is
+  therefore invariant under strictly increasing marginal transformations and
+  under permutations of the observations, including when ties are present.
+- For any rank transformation that preserves ties, including the default
+  `pseudos(u; ties=:average)`, applying that transformation first leaves the
+  empirical Kendall sample unchanged.
 
 Returns
 - `Vector{Float64}` of length `n` with values in `(0,1)`.
 """
 function _kendall_sample(u::AbstractMatrix)
-    d, n = size(u)
-    R = Matrix{Int}(undef, d, n)
-    @inbounds for i in 1:d
-        R[i, :] = StatsBase.ordinalrank(@view u[i, :])
-    end
+    _, n = size(u)
     W = zeros(Float64, n)
     @inbounds for i in 1:n
-        ri = @view R[:, i]
+        ui = @view u[:, i]
         count_le = 0
         for j in 1:n
-            count_le += all(@view(R[:, j]) .≤ ri)
+            count_le += all(@view(u[:, j]) .≤ ui)
         end
         W[i] = count_le / (n + 1)
     end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -190,61 +190,15 @@ pseudos(X) == [0.75 0.25 0.5; 0.25 0.75 0.5]
 See also: [`EmpiricalCopula`](@ref), [`BetaCopula`](@ref),
 [`CheckerboardCopula`](@ref).
 """
-const _PSEUDO_TIE_METHODS = (:average, :first, :last, :min, :max, :random)
-
-function _pseudoranks!(ranks::AbstractVector{T}, x::AbstractVector, ties::Symbol,
-        rng::Random.AbstractRNG, order::Vector{Int}) where {T<:AbstractFloat}
-    ties in _PSEUDO_TIE_METHODS || throw(ArgumentError(
-        "unsupported tie method :$ties; expected one of $(_PSEUDO_TIE_METHODS)"))
-    sortperm!(order, x; by=identity, alg=Base.Sort.DEFAULT_STABLE)
-
-    if ties === :first
-        @inbounds for (rank, index) in enumerate(order)
-            ranks[index] = T(rank)
-        end
-        return ranks
-    end
-
-    n = length(order)
-    first = 1
-    while first <= n
-        last = first
-        @inbounds while last < n && x[order[last + 1]] == x[order[first]]
-            last += 1
-        end
-
-        if ties === :average
-            rank = (T(first) + T(last)) / T(2)
-            @inbounds for k in first:last
-                ranks[order[k]] = rank
-            end
-        elseif ties === :min
-            @inbounds for k in first:last
-                ranks[order[k]] = T(first)
-            end
-        elseif ties === :max
-            @inbounds for k in first:last
-                ranks[order[k]] = T(last)
-            end
-        elseif ties === :last
-            @inbounds for k in first:last
-                ranks[order[k]] = T(last - (k - first))
-            end
-        else # :random
-            Random.shuffle!(rng, @view order[first:last])
-            @inbounds for k in first:last
-                ranks[order[k]] = T(k)
-            end
-        end
-        first = last + 1
-    end
-    return ranks
-end
-
 function pseudos(sample::AbstractMatrix; ties::Symbol=:average,
         rng::Random.AbstractRNG=Random.default_rng())
     ties in _PSEUDO_TIE_METHODS || throw(ArgumentError(
         "unsupported tie method :$ties; expected one of $(_PSEUDO_TIE_METHODS)"))
+    return _pseudos(sample, Val(ties), rng)
+end
+
+function _pseudos(sample::AbstractMatrix, tie_method::Val,
+        rng::Random.AbstractRNG)
     d, n = size(sample)
     T = float(eltype(sample))
     U = Matrix{T}(undef, d, n)
@@ -252,11 +206,111 @@ function pseudos(sample::AbstractMatrix; ties::Symbol=:average,
     @inbounds for i in 1:d
         x = @view sample[i, :]
         ranks = @view U[i, :]
-        _pseudoranks!(ranks, x, ties, rng, tmp_idx)
+        _pseudoranks!(ranks, x, tie_method, rng, tmp_idx)
         ranks ./= T(n + 1)
     end
     return U
 end
+
+const _PSEUDO_TIE_METHODS = (:average, :first, :last, :min, :max, :random)
+
+function _pseudoranks!(ranks::AbstractVector, x::AbstractVector, tie_method::Val,
+        rng::Random.AbstractRNG, order::Vector{Int})
+    sortperm!(order, x; by=identity, alg=Base.Sort.DEFAULT_STABLE)
+    return _assign_pseudoranks!(ranks, x, order, tie_method, rng)
+end
+
+function _assign_pseudoranks!(ranks::AbstractVector{T}, ::AbstractVector,
+        order::Vector{Int}, ::Val{:first}, ::Random.AbstractRNG) where {T}
+    @inbounds for (rank, index) in enumerate(order)
+        ranks[index] = T(rank)
+    end
+    return ranks
+end
+
+function _assign_tied_pseudoranks!(ranks::AbstractVector, x::AbstractVector,
+        order::Vector{Int}, tie_method::Val, rng::Random.AbstractRNG)
+    n = length(order)
+    first = 1
+    while first <= n
+        last = first
+        @inbounds while last < n && x[order[last + 1]] == x[order[first]]
+            last += 1
+        end
+        _assign_tie_group!(ranks, order, first, last, tie_method, rng)
+        first = last + 1
+    end
+    return ranks
+end
+
+function _assign_pseudoranks!(ranks::AbstractVector, x::AbstractVector,
+        order::Vector{Int}, tie_method::Val{:average}, rng::Random.AbstractRNG)
+    return _assign_tied_pseudoranks!(ranks, x, order, tie_method, rng)
+end
+
+function _assign_pseudoranks!(ranks::AbstractVector, x::AbstractVector,
+        order::Vector{Int}, tie_method::Val{:last}, rng::Random.AbstractRNG)
+    return _assign_tied_pseudoranks!(ranks, x, order, tie_method, rng)
+end
+
+function _assign_pseudoranks!(ranks::AbstractVector, x::AbstractVector,
+        order::Vector{Int}, tie_method::Val{:min}, rng::Random.AbstractRNG)
+    return _assign_tied_pseudoranks!(ranks, x, order, tie_method, rng)
+end
+
+function _assign_pseudoranks!(ranks::AbstractVector, x::AbstractVector,
+        order::Vector{Int}, tie_method::Val{:max}, rng::Random.AbstractRNG)
+    return _assign_tied_pseudoranks!(ranks, x, order, tie_method, rng)
+end
+
+function _assign_pseudoranks!(ranks::AbstractVector, x::AbstractVector,
+        order::Vector{Int}, tie_method::Val{:random}, rng::Random.AbstractRNG)
+    return _assign_tied_pseudoranks!(ranks, x, order, tie_method, rng)
+end
+
+function _assign_tie_group!(ranks::AbstractVector{T}, order::Vector{Int},
+        first::Int, last::Int, ::Val{:average}, ::Random.AbstractRNG) where {T}
+    rank = (T(first) + T(last)) / T(2)
+    @inbounds for k in first:last
+        ranks[order[k]] = rank
+    end
+    return nothing
+end
+
+function _assign_tie_group!(ranks::AbstractVector{T}, order::Vector{Int},
+        first::Int, last::Int, ::Val{:min}, ::Random.AbstractRNG) where {T}
+    @inbounds for k in first:last
+        ranks[order[k]] = T(first)
+    end
+    return nothing
+end
+
+function _assign_tie_group!(ranks::AbstractVector{T}, order::Vector{Int},
+        first::Int, last::Int, ::Val{:max}, ::Random.AbstractRNG) where {T}
+    @inbounds for k in first:last
+        ranks[order[k]] = T(last)
+    end
+    return nothing
+end
+
+function _assign_tie_group!(ranks::AbstractVector{T}, order::Vector{Int},
+        first::Int, last::Int, ::Val{:last}, ::Random.AbstractRNG) where {T}
+    @inbounds for k in first:last
+        ranks[order[k]] = T(last - (k - first))
+    end
+    return nothing
+end
+
+function _assign_tie_group!(ranks::AbstractVector{T}, order::Vector{Int},
+        first::Int, last::Int, ::Val{:random}, rng::Random.AbstractRNG) where {T}
+    Random.shuffle!(rng, @view order[first:last])
+    @inbounds for k in first:last
+        ranks[order[k]] = T(k)
+    end
+    return nothing
+end
+
+
 
 function _require_tie_free_rows(sample::AbstractMatrix, operation::AbstractString)
     for row in axes(sample, 1)

--- a/test/api/constructor_validation.jl
+++ b/test/api/constructor_validation.jl
@@ -8,6 +8,12 @@
     @test_throws ArgumentError BetaCopula(tied)
     @test_throws ArgumentError CheckerboardCopula(tied; m=2, pseudo_values=false)
     @test_throws ArgumentError BernsteinCopula(tied; m=2, pseudo_values=false)
+    for ties in (:first, :last, :random)
+        ranked = pseudos(tied; ties, rng=Xoshiro(42))
+        @test BetaCopula(ranked) isa BetaCopula
+        @test CheckerboardCopula(ranked; m=2) isa CheckerboardCopula
+        @test BernsteinCopula(ranked; m=2) isa BernsteinCopula
+    end
     @test_throws DimensionMismatch GaussianCopula{3}([1.0 0.2; 0.2 1.0])
     @test_throws DimensionMismatch NestedArchimedeanCopula{3}(
         Copulas.ClaytonGenerator(1.0);

--- a/test/api/constructor_validation.jl
+++ b/test/api/constructor_validation.jl
@@ -3,7 +3,11 @@
 
 @testset "constructor validation regressions" begin
     data = [0.1 0.4 0.8 0.6; 0.3 0.9 0.2 0.7]
+    tied = [0.1 0.1 0.8 0.9; 0.2 0.4 0.6 0.7]
     @test_throws DimensionMismatch EmpiricalCopula{3}(data)
+    @test_throws ArgumentError BetaCopula(tied)
+    @test_throws ArgumentError CheckerboardCopula(tied; m=2, pseudo_values=false)
+    @test_throws ArgumentError BernsteinCopula(tied; m=2, pseudo_values=false)
     @test_throws DimensionMismatch GaussianCopula{3}([1.0 0.2; 0.2 1.0])
     @test_throws DimensionMismatch NestedArchimedeanCopula{3}(
         Copulas.ClaytonGenerator(1.0);

--- a/test/api/utilities.jl
+++ b/test/api/utilities.jl
@@ -46,6 +46,13 @@
     @test pseudos(Utied) == Utied
     @test_throws ArgumentError pseudos(Xtied; ties=:dense)
 
+    kendall_data = [1.0 1.0 2.0 3.0; 1.0 2.0 1.0 3.0]
+    kendall = Copulas._kendall_sample(kendall_data)
+    @test kendall == [1.0, 2.0, 2.0, 4.0] ./ 5
+    @test Copulas._kendall_sample(pseudos(kendall_data)) == kendall
+    permuted_kendall = Copulas._kendall_sample(kendall_data[:, permutation])
+    @test permuted_kendall[invperm(permutation)] == kendall
+
 
     target = [1.0 0.4; 0.4 1.0]
     @test Nataf((Normal(), Normal(2, 3)), target) == target

--- a/test/api/utilities.jl
+++ b/test/api/utilities.jl
@@ -21,6 +21,16 @@
     @test pseudos(Xtied; ties=:max) ==
           [2.0 2.0 3.0 4.0; 4.0 3.0 3.0 1.0] ./ denominator
 
+    for row in axes(Xtied, 1)
+        x = @view Xtied[row, :]
+        @test pseudos(reshape(x, 1, :); ties=:average)[1, :] .* denominator ==
+              StatsBase.tiedrank(x)
+        @test pseudos(reshape(x, 1, :); ties=:first)[1, :] .* denominator ==
+              StatsBase.ordinalrank(x)
+        @test pseudos(reshape(x, 1, :); ties=:min)[1, :] .* denominator ==
+              StatsBase.competerank(x)
+    end
+
     random1 = pseudos(Xtied; ties=:random, rng=Xoshiro(93))
     random2 = pseudos(Xtied; ties=:random, rng=Xoshiro(93))
     @test random1 == random2

--- a/test/api/utilities.jl
+++ b/test/api/utilities.jl
@@ -37,10 +37,12 @@
     @test sort(random1[1, 1:2]) == [1.0, 2.0] ./ denominator
     @test sort(random1[2, 2:3]) == [2.0, 3.0] ./ denominator
 
-    rng = Xoshiro(94)
-    control = Xoshiro(94)
-    pseudos(Xtied; ties=:average, rng)
-    @test rand(rng) == rand(control)
+    for ties in (:average, :first, :last, :min, :max)
+        rng = Xoshiro(94)
+        control = Xoshiro(94)
+        pseudos(Xtied; ties, rng)
+        @test rand(rng) == rand(control)
+    end
 
     permutation = [4, 2, 1, 3]
     for ties in (:average, :min, :max)

--- a/test/api/utilities.jl
+++ b/test/api/utilities.jl
@@ -8,6 +8,45 @@
     @test pseudos(U) == U
     @test eltype(pseudos(Float32.(X))) === Float32
 
+    Xtied = [1.0 1.0 2.0 4.0; 4.0 3.0 3.0 1.0]
+    denominator = 5
+    @test pseudos(Xtied; ties=:average) ==
+          [1.5 1.5 3.0 4.0; 4.0 2.5 2.5 1.0] ./ denominator
+    @test pseudos(Xtied; ties=:first) ==
+          [1.0 2.0 3.0 4.0; 4.0 2.0 3.0 1.0] ./ denominator
+    @test pseudos(Xtied; ties=:last) ==
+          [2.0 1.0 3.0 4.0; 4.0 3.0 2.0 1.0] ./ denominator
+    @test pseudos(Xtied; ties=:min) ==
+          [1.0 1.0 3.0 4.0; 4.0 2.0 2.0 1.0] ./ denominator
+    @test pseudos(Xtied; ties=:max) ==
+          [2.0 2.0 3.0 4.0; 4.0 3.0 3.0 1.0] ./ denominator
+
+    random1 = pseudos(Xtied; ties=:random, rng=Xoshiro(93))
+    random2 = pseudos(Xtied; ties=:random, rng=Xoshiro(93))
+    @test random1 == random2
+    @test sort(random1[1, 1:2]) == [1.0, 2.0] ./ denominator
+    @test sort(random1[2, 2:3]) == [2.0, 3.0] ./ denominator
+
+    rng = Xoshiro(94)
+    control = Xoshiro(94)
+    pseudos(Xtied; ties=:average, rng)
+    @test rand(rng) == rand(control)
+
+    permutation = [4, 2, 1, 3]
+    for ties in (:average, :min, :max)
+        ranked = pseudos(Xtied; ties)
+        permuted = pseudos(Xtied[:, permutation]; ties)
+        @test permuted[:, invperm(permutation)] == ranked
+    end
+
+    for ties in (:average, :first, :last, :min, :max, :random)
+        @test pseudos(X; ties, rng=Xoshiro(95)) == U
+    end
+    Utied = pseudos(Xtied)
+    @test pseudos(Utied) == Utied
+    @test_throws ArgumentError pseudos(Xtied; ties=:dense)
+
+
     target = [1.0 0.4; 0.4 1.0]
     @test Nataf((Normal(), Normal(2, 3)), target) == target
     @test Nataf([Normal(), Normal(2, 3)], target) == target


### PR DESCRIPTION
Closes #467.

## Summary

- use average ranks as the default convention for pseudo-observations;
- expose :average, :first, :last, :min, :max, and :random through the ties keyword;
- support reproducible random tie breaking with an explicit RNG;
- dispatch tie strategies through Val outside the tie-group loop;
- use StatsBase ranking functions as independent test oracles where applicable;
- preserve equal observations in empirical Kendall samples;
- keep continuous-margin hypothesis tests strict about rejecting tied inputs;
- reject raw tied margins in empirical constructors that require distinct rank grids;
- document the statistical interpretation and compatibility change.

## Compatibility

Untied samples produce the same pseudo-observations as before. For tied samples, the new default is deterministic and invariant to observation order. The previous behavior remains available explicitly with ties=:first.

## Validation

The complete test suite and documentation build are delegated to CI, as requested.