### PR TITLE
Define stable MLE and MPL fitting semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,8 +195,8 @@ Notes
   pseudo_values=false` for maximum pseudo-likelihood from raw observations.
 - Sklar fits default to sequential `sklar_method=:ifm`; `:ecdf` is the
   rank-based alternative. Neither route is joint full maximum likelihood.
-- Their copula step defaults to `copula_method=:mle`, replaceable by another
-  family-supported method such as `:itau` or `:irho`.
+- Their copula step defaults to `copula_method=:mle` when supported, otherwise
+  to the family's advertised default; either can be replaced explicitly.
 
 Use `CopulaModel` when diagnostics and inference matter. If the family is not
 known in advance, fit an explicit, scientifically appropriate candidate set and

--- a/README.md
+++ b/README.md
@@ -191,8 +191,12 @@ Ĉ = fit(GumbelCopula, U; method=:itau)
 ```
 
 Notes
-- `fit` chooses a reasonable default per family; pass `method`/`copula_method` to control it.
-- Common methods: copulas `:mle`, `:itau`, `:irho`, `:ibeta`; Sklar `:ifm` (parametric CDFs) and `:ecdf` (pseudo-observations).
+- Direct copula fits default to `method=:mle`. Use `method=:mpl,
+  pseudo_values=false` for maximum pseudo-likelihood from raw observations.
+- Sklar fits default to sequential `sklar_method=:ifm`; `:ecdf` is the
+  rank-based alternative. Neither route is joint full maximum likelihood.
+- Their copula step defaults to `copula_method=:mle`, replaceable by another
+  family-supported method such as `:itau` or `:irho`.
 
 Use `CopulaModel` when diagnostics and inference matter. If the family is not
 known in advance, fit an explicit, scientifically appropriate candidate set and

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -193,8 +193,8 @@ Notes
   pseudo_values=false` for maximum pseudo-likelihood from raw observations.
 - Sklar fits default to sequential `sklar_method=:ifm`; `:ecdf` is the
   rank-based alternative. Neither route is joint full maximum likelihood.
-- Their copula step defaults to `copula_method=:mle`, replaceable by another
-  family-supported method such as `:itau` or `:irho`.
+- Their copula step defaults to `copula_method=:mle` when supported, otherwise
+  to the family's advertised default; either can be replaced explicitly.
 
 Use `CopulaModel` when diagnostics and inference matter. If the family is not
 known in advance, fit an explicit, scientifically appropriate candidate set and

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -189,8 +189,12 @@ Ĉ = fit(GumbelCopula, U; method=:itau)
 ```
 
 Notes
-- `fit` chooses a reasonable default per family; pass `method`/`copula_method` to control it.
-- Common methods: copulas `:mle`, `:itau`, `:irho`, `:ibeta`; Sklar `:ifm` (parametric CDFs) and `:ecdf` (pseudo-observations).
+- Direct copula fits default to `method=:mle`. Use `method=:mpl,
+  pseudo_values=false` for maximum pseudo-likelihood from raw observations.
+- Sklar fits default to sequential `sklar_method=:ifm`; `:ecdf` is the
+  rank-based alternative. Neither route is joint full maximum likelihood.
+- Their copula step defaults to `copula_method=:mle`, replaceable by another
+  family-supported method such as `:itau` or `:irho`.
 
 Use `CopulaModel` when diagnostics and inference matter. If the family is not
 known in advance, fit an explicit, scientifically appropriate candidate set and

--- a/docs/src/manual/fitting_interface.md
+++ b/docs/src/manual/fitting_interface.md
@@ -357,6 +357,14 @@ MLE once marginal families can explicitly provide this optimization protocol;
 the continuous, discrete and mixed-margin likelihood cases must also be
 distinguished.
 
+There is a second, statistical limitation: `Distributions.fit` is a common
+entry point, not a universal promise that every marginal family uses maximum
+likelihood. Its estimator is chosen by the individual distribution
+implementation and is not exposed to Copulas.jl through a stable protocol; for
+some families it may use another fitting principle altogether. Consequently,
+independently calling `fit` on every margin neither identifies a joint MLE nor
+even guarantees that every marginal block was estimated by marginal MLE.
+
 :::
 
 ::: property Identifiability of inversion estimators

--- a/docs/src/manual/fitting_interface.md
+++ b/docs/src/manual/fitting_interface.md
@@ -291,8 +291,10 @@ You can pass the `sklar_method` parameter as:
 - `:ecdf`: uses empirical pseudo-observations (ranks).
 
 The default is `sklar_method=:ifm`. In either route the copula step defaults to
-`copula_method=:mle`, but it can be replaced by any method supported by the
-chosen family, such as `:itau` or `:irho`.
+`copula_method=:mle` whenever that estimator is supported. Empirical or
+extension-defined families without MLE retain their first advertised method.
+The default can be replaced by any method supported by the chosen family, such
+as `:itau` or `:irho`.
 
 ::: remark IFM or empirical margins?
 
@@ -309,7 +311,7 @@ S = SklarDist(ClaytonCopula(2, 5), (Normal(), LogNormal(0, 0.5)))
 X = rand(S, 300)
 Ŝ = fit(CopulaModel, SklarDist{ClaytonCopula,Tuple{Normal,LogNormal}}, X;
 	sklar_method=:ifm, # or :ecdf
-	copula_method=:mle, # or another method supported by the copula family
+	copula_method=:default, # MLE when available; otherwise the family's default
 	margins_kwargs=NamedTuple(), copula_kwargs=NamedTuple()) # options will be passed down to fitting functions. 
 Ŝ
 ```

--- a/docs/src/manual/fitting_interface.md
+++ b/docs/src/manual/fitting_interface.md
@@ -24,6 +24,17 @@ coefficients to their theoretical values.
 
 :::
 
+::: definition Maximum likelihood and maximum pseudo-likelihood
+
+Maximum likelihood (`method=:mle`) maximizes the copula density over values
+already observed on the uniform copula scale. Maximum pseudo-likelihood
+(`method=:mpl`) first replaces raw marginal observations by their empirical
+ranks and then maximizes the same numerical objective. The point optimizer is
+the same, but the two estimators make different assumptions about how the
+uniform observations were obtained.
+
+:::
+
 ## From a point estimate to a statistical model
 
 ### A fitted copula
@@ -45,7 +56,7 @@ not enough. `CopulaModel` retains the likelihood, fitting method, convergence
 information and, when requested, an estimate of parameter uncertainty:
 
 ```@example fitting_interface
-M = fit(CopulaModel, GumbelCopula, U; method=:default)
+M = fit(CopulaModel, GumbelCopula, U; method=:mle)
 ```
 
 The fitted distribution is available through the standard model interface;
@@ -147,8 +158,8 @@ the selection step.
 Usually, the model is identified by a copula or Sklar type, for example
 `fit(GumbelCopula, U)` or
 `fit(CopulaModel, SklarDist{ClaytonCopula,Tuple{Normal,LogNormal}}, X)`. With
-`method=:default`, each family chooses its documented default estimator;
-explicitly supported methods depend on the family.
+direct copula calls default to `method=:mle`; explicitly supported alternatives
+depend on the family.
 
 The form `SklarDist{CopulaType,Tuple{MarginTypes...}}` is intentionally public
 syntax for this purpose: it selects the copula family and the ordered marginal
@@ -274,16 +285,22 @@ For raw observations, fitting a `SklarDist` separates two questions: how each
 margin should be estimated, and how the transformed observations should be used
 to estimate dependence.
 
-You can pass the `sklar_method` parameter as: 
+You can pass the `sklar_method` parameter as:
 
 - `:ifm`: fits parametric margins and maps data to pseudo-scale via their CDFs.  
 - `:ecdf`: uses empirical pseudo-observations (ranks).
+
+The default is `sklar_method=:ifm`. In either route the copula step defaults to
+`copula_method=:mle`, but it can be replaced by any method supported by the
+chosen family, such as `:itau` or `:irho`.
 
 ::: remark IFM or empirical margins?
 
 - Use `sklar_method = :ifm` when margins are plausibly parametric and you want a model-based projection; use `:ecdf` to avoid margin misspecification.
 - `margins_kwargs` is a single `NamedTuple` applied to every marginal fit. For heterogeneous options, fit margins manually and then fit the copula on the resulting pseudo-data.
 - The model’s `null_ll` (for LR tests) is the log-likelihood under independence with the **same margins**.
+- Neither route jointly maximizes the complete Sklar likelihood: IFM is
+  sequential, while ECDF estimates dependence from ranks.
 
 :::
 
@@ -292,7 +309,7 @@ S = SklarDist(ClaytonCopula(2, 5), (Normal(), LogNormal(0, 0.5)))
 X = rand(S, 300)
 Ŝ = fit(CopulaModel, SklarDist{ClaytonCopula,Tuple{Normal,LogNormal}}, X;
 	sklar_method=:ifm, # or :ecdf
-	copula_method=:default, # see next section. 
+	copula_method=:mle, # or another method supported by the copula family
 	margins_kwargs=NamedTuple(), copula_kwargs=NamedTuple()) # options will be passed down to fitting functions. 
 Ŝ
 ```
@@ -305,19 +322,42 @@ plot(fitteddistribution(Ŝ))
 
 ## Choosing an estimating principle
 
-The names and availability of fitting methods depend on the family. Use
-`method=:default` unless a family documents a more appropriate explicit method.
+The names and availability of fitting methods depend on the family. Direct
+copula fitting defaults to `method=:mle`; choose another estimator explicitly.
 
 The fitting method determines which feature of the sample identifies the
 parameters. No method dominates in every family and sample size.
 
 - `:mle` — **Maximum likelihood** over `U`. Recommended when a stable density and a good reparameterization exist.
+- `:mpl` — **Maximum pseudo-likelihood**. With `pseudo_values=false`, raw
+  observations are converted by `pseudos` before the copula likelihood is
+  maximized. This method is available whenever `:mle` is available, but is
+  never selected by default.
 - `:itau` — **Kendall inverse**: matches theoretical `tau(C)` to empirical `tau(U)`. Ideal for single-parameter families with a monotone inverse.
 - `:irho` — **Spearman inverse**: analogous to `rho`; can use scalar or matrix objectives (e.g., multivariate Gaussians).
 - `:ibeta` — **Blomqvist inverse**: scalar; only valid for families with **≤ 1** free parameter.
 - `:itau_irho` — **joint Kendall/Spearman matching** for a bivariate
   `TCopula`: Kendall's tau determines the correlation parameter and Spearman's
   rho determines the degrees of freedom.
+
+The two likelihood names are kept consistent with the preprocessing request.
+Asking for `method=:mle, pseudo_values=false` silently records the effective
+method as `:mpl`. Asking for `method=:mpl, pseudo_values=true` records `:mle`
+and warns, because no rank transformation occurs.
+
+::: remark Why there is no full Sklar MLE yet
+
+A generic joint optimizer would need a smooth unconstrained parameterization
+for every requested marginal family. `Distributions.jl` does not expose enough
+information to derive such mappings from `params` and constructors: marginal
+parameters may be positive, bounded, ordered, matrix-valued, mutually
+constrained, or may alter the support. Guessing those constraints would make a
+nominally generic method unreliable. A future API extension can add full Sklar
+MLE once marginal families can explicitly provide this optimization protocol;
+the continuous, discrete and mixed-margin likelihood cases must also be
+distinguished.
+
+:::
 
 ::: property Identifiability of inversion estimators
 

--- a/docs/src/manual/fitting_interface.md
+++ b/docs/src/manual/fitting_interface.md
@@ -323,7 +323,11 @@ plot(fitteddistribution(Ŝ))
 ## Choosing an estimating principle
 
 The names and availability of fitting methods depend on the family. Direct
-copula fitting defaults to `method=:mle`; choose another estimator explicitly.
+parametric copula fitting defaults to `method=:mle` whenever MLE is available;
+choose another estimator explicitly. Structural, empirical, or selection
+families without an MLE retain the first method advertised by their
+`_available_fitting_methods` extension hook. This preserves extension-defined
+defaults without ever selecting `:mpl` implicitly.
 
 The fitting method determines which feature of the sample identifies the
 parameters. No method dominates in every family and sample size.

--- a/docs/src/manual/intro.md
+++ b/docs/src/manual/intro.md
@@ -323,8 +323,12 @@ Copulas.τ(Ĉ)
 ```
 
 Notes:
-- `fit` chooses a reasonable default per-family; pass `method`/`copula_method` to control it.
-- Common copula methods include `:mle`, `:itau`, `:irho`, `:ibeta`; for Sklar fitting, `:ifm` (parametric CDFs) and `:ecdf` (pseudo-observations) are available.
+- Direct copula fits default to `method=:mle`; `method=:mpl` ranks raw data
+  when used with `pseudo_values=false`.
+- Sklar fits default to sequential `sklar_method=:ifm`; `:ecdf` is the
+  rank-based alternative. Neither route is a joint full-likelihood fit.
+- The Sklar copula step defaults to `copula_method=:mle` and can be replaced by
+  another family-supported method such as `:itau` or `:irho`.
 - `CopulaModel` implements model stats: `nobs`, `coef`, `vcov`, `stderror`, `confint`, `aic/bic`, `nullloglikelihood`, and more.
 - For a Bayesian workflow over Sklar models, see the examples section.
 

--- a/docs/src/manual/intro.md
+++ b/docs/src/manual/intro.md
@@ -327,8 +327,9 @@ Notes:
   when used with `pseudo_values=false`.
 - Sklar fits default to sequential `sklar_method=:ifm`; `:ecdf` is the
   rank-based alternative. Neither route is a joint full-likelihood fit.
-- The Sklar copula step defaults to `copula_method=:mle` and can be replaced by
-  another family-supported method such as `:itau` or `:irho`.
+- The Sklar copula step defaults to `copula_method=:mle` when supported,
+  otherwise to the family's advertised default; either can be replaced
+  explicitly.
 - `CopulaModel` implements model stats: `nobs`, `coef`, `vcov`, `stderror`, `confint`, `aic/bic`, `nullloglikelihood`, and more.
 - For a Bayesian workflow over Sklar models, see the examples section.
 

--- a/src/CopulaTest.jl
+++ b/src/CopulaTest.jl
@@ -787,10 +787,11 @@ function GOFCopulaTest(M::CopulaModel; kwargs...)
     haskey(M.method_details, :U) || throw(ArgumentError("the fitted model does not store its fitting sample"))
 
     # Most copula fits receive pseudo-observations directly. Empirical fitting
-    # routines may instead have received raw data with `pseudo_values=false`;
-    # respect that metadata rather than silently treating the stored input as
-    # already ranked.
-    stored_pseudo_values = get(M.method_details, :pseudo_values, true)
+    # New likelihood fits distinguish the caller's raw-input flag from the
+    # transformed matrix retained for inference. Older and empirical fit
+    # records continue to use `pseudo_values` directly.
+    stored_pseudo_values = get(M.method_details, :fitting_data_pseudo_values,
+        get(M.method_details, :pseudo_values, true))
 
     return _run_copula_test(GoodnessOfFitHypothesis(M), M.method_details.U; pseudo_values=stored_pseudo_values, kwargs...,)
 end

--- a/src/Fitting.jl
+++ b/src/Fitting.jl
@@ -126,8 +126,11 @@ function _refit(M::CopulaModel, U::AbstractMatrix)
         "composite goodness-of-fit refitting is unavailable for this model"))
 
     kwargs = _refit_kwargs(spec.kwargs)
+    # Composite GOF refits receive pseudo-observations already. MPL uses the
+    # same numerical likelihood engine as MLE, without ranking these again.
+    method = spec.method === :mpl ? :mle : spec.method
 
-    return Distributions.fit(CopulaModel, spec.target, U; method=spec.method, derived_measures=false, vcov=false, kwargs...,)
+    return Distributions.fit(CopulaModel, spec.target, U; method, derived_measures=false, vcov=false, kwargs...,)
 end
 
 # Fallbacks that throw if the interface is not implemented correctly.
@@ -271,8 +274,10 @@ and fitting method.
 
 Return the tuple of fitting methods available for a given copula family in a given dimension.
 
-This is used internally by [`Distributions.fit`](@ref) to check validity of the `method` argument
-and to select a default method when `method=:default`.
+This is used internally by [`Distributions.fit`](@ref) to check validity of the
+`method` argument. Maximum pseudo-likelihood (`:mpl`) is a public semantic alias
+of the `:mle` engine and is therefore accepted whenever `:mle` appears in this
+tuple, without requiring every family to duplicate the same implementation.
 
 # Example
 ```julia
@@ -286,28 +291,44 @@ See also: [`_fit`](@ref), [`_example`](@ref),
 _available_fitting_methods(::Type{<:Copula}, d) = (:mle, :itau, :irho, :ibeta)
 _available_fitting_methods(C::Copula, d) = _available_fitting_methods(typeof(C), d)
 
+function _supports_fitting_method(CT, d, method)
+    available = _available_fitting_methods(CT, d)
+    return method in available || (method === :mpl && :mle in available)
+end
+
 function _find_method(CT, d, method)
     avail = _available_fitting_methods(CT, d)
     isempty(avail) && throw(ArgumentError("No fitting methods available for $CT."))
     method === :default && return avail[1]
-    method ∉ avail && throw(ArgumentError(
-        "Method '$method' not available for $CT. Available: $(join(avail, ", ")).",
+    !_supports_fitting_method(CT, d, method) && throw(ArgumentError(
+        "Method '$method' not available for $CT. Available: $(join(avail, ", "))." *
+        (:mle in avail ? " Maximum pseudo-likelihood (:mpl) is also available." : ""),
     ))
     return method
 end
 
-"""
-    fit(CopulaModel, CT::Type{<:Copula}, U; method=:default, kwargs...)
+function _normalize_likelihood_fit(method::Symbol, pseudo_values::Bool)
+    if method === :mle && !pseudo_values
+        return :mpl
+    elseif method === :mpl && pseudo_values
+        @warn "method=:mpl requires raw observations; because pseudo_values=true, fitting proceeds as method=:mle"
+        return :mle
+    end
+    return method
+end
 
-Fit a copula of type `CT` to pseudo-observations `U`.
+"""
+    fit(CopulaModel, CT::Type{<:Copula}, data;
+        method=:mle, pseudo_values=true, kwargs...)
+
+Fit a copula of type `CT` by maximum likelihood or another supported estimator.
 
 # Arguments
-- `U::AbstractMatrix` — a `d×n` matrix of data (each column is an observation).
-  If the input is raw data, use `SklarDist` fitting instead to estimate both
-  margins and copula simultaneously.
-- `method::Symbol`    — fitting method; defaults to the family's preferred
-  supported method. Family documentation lists the available choices, and an
-  unsupported value raises an `ArgumentError` that reports them.
+- `data::AbstractMatrix` — a `d×n` matrix with observations in columns.
+- `pseudo_values::Bool` — whether `data` is already on the copula scale. Pass
+  `false` to rank-transform raw observations with [`pseudos`](@ref).
+- `method::Symbol` — fitting method, defaulting to `:mle`. `:mpl` denotes
+  maximum pseudo-likelihood.
 - `kwargs...`         — additional method-specific keyword arguments
   (e.g. `pseudo_values=true`, `grid=401` for extreme-value tails, etc.).
 
@@ -329,22 +350,42 @@ Inference controls such as `vcov` and `derived_measures` affect the returned
 model metadata, not the point estimator. Covariance availability depends on
 the family, method and numerical regularity; `vcov=false` skips that work.
 
+`method=:mle, pseudo_values=false` is normalized silently to `:mpl`, since the
+rank transformation changes the statistical estimator. Conversely,
+`method=:mpl, pseudo_values=true` is normalized to `:mle` with a warning because
+no pseudo-observations are then constructed. Both use the same numerical
+copula-likelihood optimizer; the distinction records the input's provenance.
+
 See also: [`CopulaModel`](@ref), [`selectiontable`](@ref),
 [`GOFCopulaTest`](@ref).
 """
 function Distributions.fit(::Type{CopulaModel}, CT::Type{<:Copula}, U;
-        method=:default, quick_fit=false, derived_measures=true,
-        vcov=true, vcov_method=nothing, kwargs...)
+        method=:mle, pseudo_values::Union{Nothing,Bool}=nothing, quick_fit=false,
+        derived_measures=true, vcov=true, vcov_method=nothing, kwargs...)
     _check_vcov_method(vcov_method)
     d, n = size(U)
-    method = _find_method(CT, d, method)
-    fit_spec = _CopulaFitSpec(CT, method, (; kwargs...))
-    t = @elapsed (rez = _fit(CT, U, Val{method}(); kwargs...))
+    requested_method = method === :default ? :mle : method
+    _find_method(CT, d, requested_method)
+    likelihood_method = requested_method in (:mle, :mpl)
+    input_is_pseudo = something(pseudo_values, true)
+    method = likelihood_method ?
+        _normalize_likelihood_fit(requested_method, input_is_pseudo) :
+        requested_method
+    fit_data = method === :mpl ? pseudos(U) : U
+    engine_method = method === :mpl ? :mle : method
+    engine_kwargs = !likelihood_method && pseudo_values !== nothing ?
+        (; pseudo_values=input_is_pseudo, kwargs...) : (; kwargs...)
+    fit_kwargs = likelihood_method ?
+        (; pseudo_values=input_is_pseudo, kwargs...) : engine_kwargs
+    fit_spec = _CopulaFitSpec(CT, method, fit_kwargs)
+    t = @elapsed (rez = _fit(CT, fit_data, Val{engine_method}(); engine_kwargs...))
     C, meta = rez
     quick_fit && return (result=C,) # as soon as possible.
-    ll = Distributions.loglikelihood(C, U)
+    ll = Distributions.loglikelihood(C, fit_data)
+    meta = (; meta..., requested_method, pseudo_values=input_is_pseudo,
+        fitting_data_pseudo_values=true)
 
-    return _finish_copula_fit(CT, C, U, ll, method, meta, t, fit_spec;
+    return _finish_copula_fit(CT, C, fit_data, ll, method, meta, t, fit_spec;
         derived_measures, vcov, vcov_method)
 end
 
@@ -391,7 +432,7 @@ end
 _available_fitting_methods(::Type{SklarDist}, d) = (:ifm, :ecdf)
 """
     fit(CopulaModel, SklarDist{CT,TplMargins}, X;
-        copula_method=:default, sklar_method=:default,
+        copula_method=:mle, sklar_method=:ifm,
         margins_kwargs=NamedTuple(), copula_kwargs=NamedTuple(), kwargs...)
 
 Fit the margins and dependence structure of a Sklar distribution to a `d × n`
@@ -403,6 +444,15 @@ uniform scale before the copula is fitted. With `:ecdf`, rank
 pseudo-observations are used instead, although the requested parametric margins
 are still fitted for the returned distribution. `margins_kwargs` are forwarded
 to every marginal fit and `copula_kwargs` to the copula fit.
+
+Both routes are sequential estimators, not joint maximum likelihood for the
+complete Sklar distribution. Generic joint MLE is deliberately unavailable:
+`Distributions.jl` margin families do not expose a common protocol mapping
+their positive, bounded, ordered or interdependent parameters to an
+unconstrained optimization vector. `params` and a constructor alone cannot
+provide that information safely. The default is therefore `sklar_method=:ifm`;
+both Sklar routes request `copula_method=:mle` by default, and that copula step
+may be replaced by another method supported by `CT`.
 
 The result is a `CopulaModel` whose `result` is the fitted `SklarDist` and whose
 coefficient and covariance summaries combine the marginal and copula blocks.
@@ -416,7 +466,7 @@ marginal families. This exception does not expose arbitrary storage type
 parameters or the concrete representation of constructed `SklarDist` values.
 """
 function Distributions.fit(::Type{CopulaModel}, ::Type{SklarDist{CT,TplMargins}}, X; quick_fit = false,
-                           copula_method = :default, sklar_method = :default, margins_kwargs = NamedTuple(),
+                           copula_method = :mle, sklar_method = :ifm, margins_kwargs = NamedTuple(),
                            copula_kwargs = NamedTuple(), derived_measures = true, vcov = true,
                            vcov_method=nothing) where {CT<:Copulas.Copula, TplMargins<:Tuple}
 
@@ -1225,7 +1275,7 @@ function selectiontable(M::CopulaModel)
 end
 
 """
-    fit(CopulaModel, Copula, U; candidates, criterion=:bic, method=:default, kwargs...)
+    fit(CopulaModel, Copula, U; candidates, criterion=:bic, method=:mle, kwargs...)
 
 Fit an explicit collection of candidate families and select the smallest finite
 information criterion (`:bic`, `:aic`, `:aicc`, or `:hqc`). The winning fit is
@@ -1237,7 +1287,7 @@ Failed candidates are recorded with `on_error=:skip`, or rethrown with
 is not yet supported.
 """
 function Distributions.fit(::Type{CopulaModel}, ::Type{Copula}, U;
-        candidates, criterion::Symbol=:bic, method::Symbol=:default,
+        candidates, criterion::Symbol=:bic, method::Symbol=:mle,
         on_error::Symbol=:skip, require_convergence::Bool=true,
         quick_fit::Bool=false, derived_measures::Bool=true, vcov::Bool=true,
         vcov_method=nothing, kwargs...)
@@ -1287,7 +1337,8 @@ function Distributions.fit(::Type{CopulaModel}, ::Type{Copula}, U;
     quick_fit && return (result=best.result,)
 
     CT = rows[best_index].candidate
-    selected = _finish_copula_fit(CT, best.result, U, best.ll, best.method,
+    selected = _finish_copula_fit(CT, best.result, best.method_details.U,
+        best.ll, best.method,
         (; best.method_details..., converged=best.converged, iterations=best.iterations),
         best.elapsed_sec, nothing;
         derived_measures, vcov, vcov_method)

--- a/src/Fitting.jl
+++ b/src/Fitting.jl
@@ -454,6 +454,13 @@ provide that information safely. The default is therefore `sklar_method=:ifm`;
 both Sklar routes request `copula_method=:mle` by default, and that copula step
 may be replaced by another method supported by `CT`.
 
+Moreover, calling `Distributions.fit` for a margin does not establish a generic
+maximum-likelihood contract. The fitting algorithm is selected by each
+distribution family and is not exposed here as a stable estimator protocol; it
+may therefore differ between margins and need not be maximum likelihood. A
+joint Sklar MLE cannot safely treat those independent calls as MLE building
+blocks without a stronger upstream or Copulas.jl-specific interface.
+
 The result is a `CopulaModel` whose `result` is the fitted `SklarDist` and whose
 coefficient and covariance summaries combine the marginal and copula blocks.
 Inference for a block may be unavailable when its estimator does not supply a

--- a/src/Fitting.jl
+++ b/src/Fitting.jl
@@ -388,7 +388,7 @@ function Distributions.fit(::Type{CopulaModel}, CT::Type{<:Copula}, U;
     quick_fit && return (result=C,) # as soon as possible.
     ll = Distributions.loglikelihood(C, fit_data)
     meta = (; meta..., requested_method, pseudo_values=input_is_pseudo,
-        fitting_data_pseudo_values=true)
+        fitting_data_pseudo_values=likelihood_method ? true : input_is_pseudo)
 
     return _finish_copula_fit(CT, C, fit_data, ll, method, meta, t, fit_spec;
         derived_measures, vcov, vcov_method)
@@ -437,7 +437,7 @@ end
 _available_fitting_methods(::Type{SklarDist}, d) = (:ifm, :ecdf)
 """
     fit(CopulaModel, SklarDist{CT,TplMargins}, X;
-        copula_method=:mle, sklar_method=:ifm,
+        copula_method=:default, sklar_method=:ifm,
         margins_kwargs=NamedTuple(), copula_kwargs=NamedTuple(), kwargs...)
 
 Fit the margins and dependence structure of a Sklar distribution to a `d × n`
@@ -456,8 +456,9 @@ complete Sklar distribution. Generic joint MLE is deliberately unavailable:
 their positive, bounded, ordered or interdependent parameters to an
 unconstrained optimization vector. `params` and a constructor alone cannot
 provide that information safely. The default is therefore `sklar_method=:ifm`;
-both Sklar routes request `copula_method=:mle` by default, and that copula step
-may be replaced by another method supported by `CT`.
+both Sklar routes use `copula_method=:mle` by default whenever `CT` supports
+MLE, otherwise its first advertised fitting method. That copula step may be
+replaced by another method supported by `CT`.
 
 Moreover, calling `Distributions.fit` for a margin does not establish a generic
 maximum-likelihood contract. The fitting algorithm is selected by each
@@ -478,14 +479,15 @@ marginal families. This exception does not expose arbitrary storage type
 parameters or the concrete representation of constructed `SklarDist` values.
 """
 function Distributions.fit(::Type{CopulaModel}, ::Type{SklarDist{CT,TplMargins}}, X; quick_fit = false,
-                           copula_method = :mle, sklar_method = :ifm, margins_kwargs = NamedTuple(),
+                           copula_method = :default, sklar_method = :ifm, margins_kwargs = NamedTuple(),
                            copula_kwargs = NamedTuple(), derived_measures = true, vcov = true,
                            vcov_method=nothing) where {CT<:Copulas.Copula, TplMargins<:Tuple}
 
     # Get methods:
     d, n = size(X)
     sklar_method  = _find_method(SklarDist, d, sklar_method)
-    copula_method = _find_method(CT, d, copula_method)
+    copula_method = copula_method === :default ?
+        _default_fitting_method(CT, d) : _find_method(CT, d, copula_method)
 
     # Fit marginals:
     m = ntuple(i -> Distributions.fit(TplMargins.parameters[i], @view X[i, :]; margins_kwargs...), d)

--- a/src/Fitting.jl
+++ b/src/Fitting.jl
@@ -296,10 +296,16 @@ function _supports_fitting_method(CT, d, method)
     return method in available || (method === :mpl && :mle in available)
 end
 
+function _default_fitting_method(CT, d)
+    available = _available_fitting_methods(CT, d)
+    isempty(available) && throw(ArgumentError("No fitting methods available for $CT."))
+    return :mle in available ? :mle : first(available)
+end
+
 function _find_method(CT, d, method)
     avail = _available_fitting_methods(CT, d)
     isempty(avail) && throw(ArgumentError("No fitting methods available for $CT."))
-    method === :default && return avail[1]
+    method === :default && return _default_fitting_method(CT, d)
     !_supports_fitting_method(CT, d, method) && throw(ArgumentError(
         "Method '$method' not available for $CT. Available: $(join(avail, ", "))." *
         (:mle in avail ? " Maximum pseudo-likelihood (:mpl) is also available." : ""),
@@ -319,7 +325,7 @@ end
 
 """
     fit(CopulaModel, CT::Type{<:Copula}, data;
-        method=:mle, pseudo_values=true, kwargs...)
+        method=:default, pseudo_values=true, kwargs...)
 
 Fit a copula of type `CT` by maximum likelihood or another supported estimator.
 
@@ -327,8 +333,9 @@ Fit a copula of type `CT` by maximum likelihood or another supported estimator.
 - `data::AbstractMatrix` — a `d×n` matrix with observations in columns.
 - `pseudo_values::Bool` — whether `data` is already on the copula scale. Pass
   `false` to rank-transform raw observations with [`pseudos`](@ref).
-- `method::Symbol` — fitting method, defaulting to `:mle`. `:mpl` denotes
-  maximum pseudo-likelihood.
+- `method::Symbol` — fitting method. `:default` selects `:mle` whenever the
+  family advertises it, otherwise the family's first advertised method. `:mpl`
+  denotes maximum pseudo-likelihood and is never selected implicitly.
 - `kwargs...`         — additional method-specific keyword arguments
   (e.g. `pseudo_values=true`, `grid=401` for extreme-value tails, etc.).
 
@@ -360,11 +367,11 @@ See also: [`CopulaModel`](@ref), [`selectiontable`](@ref),
 [`GOFCopulaTest`](@ref).
 """
 function Distributions.fit(::Type{CopulaModel}, CT::Type{<:Copula}, U;
-        method=:mle, pseudo_values::Union{Nothing,Bool}=nothing, quick_fit=false,
+        method=:default, pseudo_values::Union{Nothing,Bool}=nothing, quick_fit=false,
         derived_measures=true, vcov=true, vcov_method=nothing, kwargs...)
     _check_vcov_method(vcov_method)
     d, n = size(U)
-    requested_method = method === :default ? :mle : method
+    requested_method = method === :default ? _default_fitting_method(CT, d) : method
     _find_method(CT, d, requested_method)
     likelihood_method = requested_method in (:mle, :mpl)
     input_is_pseudo = something(pseudo_values, true)

--- a/src/Fitting.jl
+++ b/src/Fitting.jl
@@ -275,9 +275,10 @@ and fitting method.
 Return the tuple of fitting methods available for a given copula family in a given dimension.
 
 This is used internally by [`Distributions.fit`](@ref) to check validity of the
-`method` argument. Maximum pseudo-likelihood (`:mpl`) is a public semantic alias
-of the `:mle` engine and is therefore accepted whenever `:mle` appears in this
-tuple, without requiring every family to duplicate the same implementation.
+`method` argument. Maximum pseudo-likelihood (`:mpl`) is handled by the
+high-level public fitting entry point whenever `:mle` appears in this tuple;
+extensions should continue to advertise and implement only their actual
+`_fit(..., Val{method})` dispatches.
 
 # Example
 ```julia
@@ -291,11 +292,6 @@ See also: [`_fit`](@ref), [`_example`](@ref),
 _available_fitting_methods(::Type{<:Copula}, d) = (:mle, :itau, :irho, :ibeta)
 _available_fitting_methods(C::Copula, d) = _available_fitting_methods(typeof(C), d)
 
-function _supports_fitting_method(CT, d, method)
-    available = _available_fitting_methods(CT, d)
-    return method in available || (method === :mpl && :mle in available)
-end
-
 function _default_fitting_method(CT, d)
     available = _available_fitting_methods(CT, d)
     isempty(available) && throw(ArgumentError("No fitting methods available for $CT."))
@@ -306,9 +302,8 @@ function _find_method(CT, d, method)
     avail = _available_fitting_methods(CT, d)
     isempty(avail) && throw(ArgumentError("No fitting methods available for $CT."))
     method === :default && return _default_fitting_method(CT, d)
-    !_supports_fitting_method(CT, d, method) && throw(ArgumentError(
-        "Method '$method' not available for $CT. Available: $(join(avail, ", "))." *
-        (:mle in avail ? " Maximum pseudo-likelihood (:mpl) is also available." : ""),
+    method ∉ avail && throw(ArgumentError(
+        "Method '$method' not available for $CT. Available: $(join(avail, ", ")).",
     ))
     return method
 end
@@ -372,7 +367,10 @@ function Distributions.fit(::Type{CopulaModel}, CT::Type{<:Copula}, U;
     _check_vcov_method(vcov_method)
     d, n = size(U)
     requested_method = method === :default ? _default_fitting_method(CT, d) : method
-    _find_method(CT, d, requested_method)
+    # MPL is a public preprocessing/metadata contract backed by the MLE
+    # engine, not an internal `_fit(..., Val{:mpl})` extension hook.
+    validation_method = requested_method === :mpl ? :mle : requested_method
+    _find_method(CT, d, validation_method)
     likelihood_method = requested_method in (:mle, :mpl)
     input_is_pseudo = something(pseudo_values, true)
     method = likelihood_method ?

--- a/test/operations/fitting.jl
+++ b/test/operations/fitting.jl
@@ -60,6 +60,7 @@ end
     @test normalized_mle.method_details.pseudo_values === true
     @test mpl_fit.method_details.U == U
     @test_throws ArgumentError Copulas._find_method(EmpiricalCopula, 2, :mpl)
+    @test_throws ArgumentError Copulas._find_method(ClaytonCopula{2}, 2, :mpl)
 end
 
 @testset "public covariance fitting option" begin
@@ -234,7 +235,6 @@ end
                 @test all(method -> Copulas._find_method(family, d, method) === method,
                           methods)
                 if :mle in methods
-                    @test Copulas._find_method(family, d, :mpl) === :mpl
                     @test Copulas._default_fitting_method(family, d) === :mle
                 else
                     @test Copulas._default_fitting_method(family, d) === first(methods)

--- a/test/operations/fitting.jl
+++ b/test/operations/fitting.jl
@@ -24,6 +24,11 @@
         vcov=false, derived_measures=false)
     @test default_model.method === :mle
     @test default_model.method_details.sklar_method === :ifm
+
+    empirical_model = fit(CopulaModel,
+        SklarDist{EmpiricalCopula,Tuple{Normal,Exponential}}, data;
+        vcov=false, derived_measures=false)
+    @test empirical_model.method === :deheuvels
 end
 
 @testset "MLE and MPL input semantics" begin

--- a/test/operations/fitting.jl
+++ b/test/operations/fitting.jl
@@ -18,6 +18,47 @@
                    sklar_method=:ecdf, copula_method=:itau, vcov=false,
                    derived_measures=false)
     @test ecdf_fit isa SklarDist
+
+    default_model = fit(CopulaModel,
+        SklarDist{ClaytonCopula,Tuple{Normal,Exponential}}, data;
+        vcov=false, derived_measures=false)
+    @test default_model.method === :mle
+    @test default_model.method_details.sklar_method === :ifm
+end
+
+@testset "MLE and MPL input semantics" begin
+    X = [2.0 8.0 1.0 5.0 3.0 7.0;
+         4.0 1.0 6.0 2.0 5.0 3.0]
+    U = pseudos(X)
+
+    default_fit = fit(CopulaModel, ClaytonCopula{2}, U;
+        vcov=false, derived_measures=false)
+    mle_fit = fit(CopulaModel, ClaytonCopula{2}, U; method=:mle,
+        pseudo_values=true, vcov=false, derived_measures=false)
+    mpl_fit = fit(CopulaModel, ClaytonCopula{2}, X; method=:mpl,
+        pseudo_values=false, vcov=false, derived_measures=false)
+    normalized_mpl = fit(CopulaModel, ClaytonCopula{2}, X; method=:mle,
+        pseudo_values=false, vcov=false, derived_measures=false)
+    normalized_mle = @test_logs (:warn, r"method=:mpl requires raw observations") fit(
+        CopulaModel, ClaytonCopula{2}, U; method=:mpl, pseudo_values=true,
+        vcov=false, derived_measures=false)
+
+    @test default_fit.method === :mle
+    @test mle_fit.method === :mle
+    @test mpl_fit.method === :mpl
+    @test normalized_mpl.method === :mpl
+    @test normalized_mle.method === :mle
+    @test params(default_fit.result) == params(mle_fit.result)
+    @test params(mpl_fit.result) == params(mle_fit.result)
+    @test params(normalized_mpl.result) == params(mpl_fit.result)
+    @test params(normalized_mle.result) == params(mle_fit.result)
+    @test mpl_fit.method_details.requested_method === :mpl
+    @test normalized_mpl.method_details.requested_method === :mle
+    @test normalized_mle.method_details.requested_method === :mpl
+    @test mpl_fit.method_details.pseudo_values === false
+    @test mpl_fit.method_details.fitting_data_pseudo_values === true
+    @test normalized_mle.method_details.pseudo_values === true
+    @test mpl_fit.method_details.U == U
 end
 
 @testset "public covariance fitting option" begin
@@ -191,6 +232,9 @@ end
                 @test Copulas._find_method(family, d, :default) in methods
                 @test all(method -> Copulas._find_method(family, d, method) === method,
                           methods)
+                if :mle in methods
+                    @test Copulas._find_method(family, d, :mpl) === :mpl
+                end
             end
         end
     end

--- a/test/operations/fitting.jl
+++ b/test/operations/fitting.jl
@@ -59,6 +59,7 @@ end
     @test mpl_fit.method_details.fitting_data_pseudo_values === true
     @test normalized_mle.method_details.pseudo_values === true
     @test mpl_fit.method_details.U == U
+    @test_throws ArgumentError Copulas._find_method(EmpiricalCopula, 2, :mpl)
 end
 
 @testset "public covariance fitting option" begin
@@ -234,6 +235,9 @@ end
                           methods)
                 if :mle in methods
                     @test Copulas._find_method(family, d, :mpl) === :mpl
+                    @test Copulas._default_fitting_method(family, d) === :mle
+                else
+                    @test Copulas._default_fitting_method(family, d) === first(methods)
                 end
             end
         end

--- a/test/operations/hypothesis_testing.jl
+++ b/test/operations/hypothesis_testing.jl
@@ -501,6 +501,7 @@ const COPULA_TEST_TINY_RESAMPLES = min(COPULA_TEST_RESAMPLES, 9)
             Mraw_refit = Copulas._refit(Mraw, Vraw)
 
             @test Mraw.method_details.pseudo_values === false
+            @test Mraw.method_details.fitting_data_pseudo_values === false
             @test Mraw_refit.method_details.pseudo_values === true
             @test Tuple(Mraw_refit.result.m) == (2, 2)
             @test teststatistic(Traw) ≈ Copulas._gof_sn_statistic(Vraw, Copulas._copula_of(Mraw))


### PR DESCRIPTION
## Summary

- add explicit maximum pseudo-likelihood semantics for direct copula fitting
- make MLE the default for MLE-capable copulas and IFM the Sklar default
- normalize contradictory `method` / `pseudo_values` combinations
- preserve requested versus effective estimator metadata and reproducible GOF refits
- preserve extension-defined defaults and exact internal method dispatch
- document why generic full-likelihood `SklarDist` fitting is intentionally deferred

## API behavior

- `method=:mle, pseudo_values=true` performs copula MLE
- `method=:mpl, pseudo_values=false` ranks raw observations and performs MPL
- `method=:mle, pseudo_values=false` silently normalizes to effective `:mpl`
- `method=:mpl, pseudo_values=true` warns and normalizes to effective `:mle`
- MLE-capable copulas default to `:mle`; MPL is never a default
- structural, empirical, and extension families without MLE retain their first advertised method
- Sklar fitting defaults to `sklar_method=:ifm` and `copula_method=:mle`
- `sklar_method=:ifm` and `:ecdf` remain sequential and allow another supported `copula_method`

Full joint Sklar MLE is not added because arbitrary `Distributions.jl` margins do not expose the constrained/unconstrained parameter mappings needed for a safe generic optimizer. In addition, `Distributions.fit` is a common fitting entry point rather than a stable guarantee that every marginal family uses maximum likelihood: the estimator depends on the distribution implementation and may follow another fitting principle. Independent marginal `fit` calls therefore cannot serve as a generic joint-MLE protocol. The documentation records these limitations and the requirements for a future extension.

## Ecosystem compatibility

VineCopulas.jl's current fitting sources were audited. They use `_available_fitting_methods`, `_find_method`, and direct `_fit(..., Val{method})` dispatch, and expose no-method `CopulaModel` fits for pair and vine families. This PR preserves those paths by retaining extension-defined defaults for families without MLE and by keeping `:mpl` normalization in the high-level public entry point rather than returning a nonexistent internal `Val{:mpl}` route from `_find_method`.

## Validation

- added CI coverage for defaults, normalization, warnings, metadata, method discovery, extension-safe dispatch, and equivalent point estimates
- local tests and documentation builds were intentionally not run; validation is delegated to CI

Closes #472
