### PR TITLE
Fix elliptical copula maximum likelihood fitting

### DIFF
--- a/src/EllipticalCopula.jl
+++ b/src/EllipticalCopula.jl
@@ -148,22 +148,57 @@ end
     return α
 end
 
-@inline function _rebound_corr_params(d::Int, α::AbstractVector{T}) where {T}
-    L = Matrix{T}(LinearAlgebra.I, d, d)
-    @inbounds begin
-        L[1,1] = one(T)
-        k = 1
-        for i in 2:d
-            denom = one(T)
-            for j in 1:i-1
-                z = tanh(α[k]); k += 1
-                L[i,j] = z * denom
-                denom *= sqrt(max(zero(T), one(T) - z*z))
-            end
-            L[i,i] = denom
+@inline function _rebound_corr_factor(d::Int, α::AbstractVector{T}) where {T}
+    L = zeros(T, d, d)
+    L[1, 1] = one(T)
+    k = 1
+    @inbounds for i in 2:d
+        denom = one(T)
+        for j in 1:(i - 1)
+            a = α[k]
+            k += 1
+            z = tanh(a)
+            L[i, j] = z * denom
+            denom *= inv(cosh(a)) # sqrt(1 - tanh(a)^2) = sech(a)
         end
+        L[i, i] = denom
     end
+    return L
+end
+
+function _score_corr_start(Z::AbstractMatrix)
+    d = size(Z, 1)
+    T = float(eltype(Z))
+    R = Matrix{T}(Statistics.cor(Z; dims=2))
+
+    if any(x -> !isfinite(x), R)
+        return Matrix{T}(LinearAlgebra.I, d, d)
+    end
+
+    R = Matrix(LinearAlgebra.Symmetric((R + R') / 2))
+    @inbounds for j in 1:d
+        R[j, j] = one(T)
+    end
+
+    LinearAlgebra.isposdef(LinearAlgebra.Symmetric(R)) && return R
+
+    I_d = Matrix{T}(LinearAlgebra.I, d, d)
+    λ = sqrt(eps(T))
+
+    while λ < one(T)
+        Rλ = (one(T) - λ) .* R .+ λ .* I_d
+        if LinearAlgebra.isposdef(LinearAlgebra.Symmetric(Rλ))
+            return Rλ
+        end
+        λ = min(one(T), 10λ)
+    end
+
+    return I_d
+end
+
+@inline function _rebound_corr_params(d::Int, α::AbstractVector{T}) where {T}
+    L = _rebound_corr_factor(d, α)
     Σ = L * L'
-    Σ = (Σ + Σ')/2
+    Σ = (Σ + Σ') / 2
     return Σ
 end

--- a/src/EllipticalCopulas/GaussianCopula.jl
+++ b/src/EllipticalCopulas/GaussianCopula.jl
@@ -89,7 +89,7 @@ function _cdf(C::CT,u) where {CT<:GaussianCopula}
     # mutable dense vector.
     x = collect(StatsBase.quantile.(Distributions.Normal(), u))
     d = length(C)
-    return MvNormalCDF.mvnormcdf(C.Σ, fill(-Inf, d), x)[1]
+    return MvNormalCDF.mvnormcdf(C.Σ, fill(-Inf, d), x; rng = Random.Xoshiro(0))[1]
 end
 
 function rosenblatt(C::GaussianCopula, u::AbstractMatrix{<:Real})

--- a/src/EllipticalCopulas/GaussianCopula.jl
+++ b/src/EllipticalCopulas/GaussianCopula.jl
@@ -162,9 +162,62 @@ end
 function _rebound_params(::Type{<:GaussianCopula}, d::Int, α::AbstractVector{T}) where {T}
     return (; Σ = _rebound_corr_params(d, α))
 end
-function _fit(CT::Type{<:GaussianCopula}, u, ::Val{:mle})
-    dd = Distributions.fit(N(CT), StatsBase.quantile.(U(CT),u))
-    Σ = Matrix(dd.Σ)
-    return GaussianCopula(Σ), (; θ̂ = (; Σ = Σ))
+function _fit(CT::Type{<:GaussianCopula}, Udata, ::Val{:mle})
+    d, n = size(Udata)
+    # Normal scores only need to be computed once.
+    N01 = Distributions.Normal()
+    Z = Distributions.quantile.(N01, Udata)
+    Q = Z * Z'    # Cross-product sufficient for the Gaussian copula likelihood.
+    if d == 2
+        q11 = Q[1, 1]; q22 = Q[2, 2]; q12 = Q[1, 2]
+        T = eltype(Q)
+        δ = sqrt(eps(T))
+        lower = -one(T) + δ
+        upper =  one(T) - δ
+
+        objective_2d = ρ -> begin
+            one_minus_ρ² = one(ρ) - ρ * ρ
+            return n / 2 * log(one_minus_ρ²) + (q11 + q22 - 2ρ * q12) / (2 * one_minus_ρ²)
+        end
+
+        res = Optim.optimize(objective_2d, lower, upper, Optim.Brent(),)
+        ρ̂ = Optim.minimizer(res)
+        R̂ = T[one(T) ρ̂; ρ̂ one(T)]
+        θ̂ = (; Σ = R̂)
+
+        return GaussianCopula(R̂), (;θ̂, optimizer  = Optim.summary(res), converged  = Optim.converged(res), iterations = Optim.iterations(res),)
+    end
+
+    # In dimensions d > 2, use the normal-score correlation only
+    # as an interior starting point.
+    R₀ = _score_corr_start(Z)
+    α₀ = _unbound_corr_params(d, R₀)
+
+    objective_hd = α -> begin
+        # The partial-correlation parameterization already gives
+        # the lower-triangular factor L such that R = L * L'.
+        L = _rebound_corr_factor(d, α)
+        Ltri = LinearAlgebra.LowerTriangular(L)
+        # log|R| = 2 * log|L|
+        logdetR = 2 * sum(log, LinearAlgebra.diag(L))
+        # tr(R^{-1} Q), using triangular solves:
+        # R^{-1} Q = L'^{-1} L^{-1} Q.
+        Y = Ltri \ Q
+        RinvQ = transpose(Ltri) \ Y
+        quadratic = LinearAlgebra.tr(RinvQ)
+
+        return (n * logdetR + quadratic) / 2
+    end
+    res = try
+    Optim.optimize(objective_hd, α₀, Optim.LBFGS();autodiff=ADTypes.AutoForwardDiff(),)
+    catch
+        Optim.optimize(objective_hd, α₀, Optim.NelderMead(),)
+    end
+    α̂ = Optim.minimizer(res)
+    L̂ = _rebound_corr_factor(d, α̂)
+    R̂ = L̂ * L̂'
+    R̂ = (R̂ + R̂') / 2
+    θ̂ = (; Σ = R̂)
+    return GaussianCopula(R̂), (;θ̂, optimizer  = Optim.summary(res), converged  = Optim.converged(res), iterations = Optim.iterations(res),)
 end
 _available_fitting_methods(::Type{<:GaussianCopula}, d) = (:mle, :itau, :irho, :ibeta)

--- a/src/EllipticalCopulas/TCopula.jl
+++ b/src/EllipticalCopulas/TCopula.jl
@@ -63,12 +63,11 @@ TCopula(d::Int, ν::Real, Σ::AbstractMatrix) = TCopula{d}(ν, Σ)
 
 
 
-U(C::TCopula) = Distributions.TDist(C.df)
-N(C::TCopula) = function(Σ)
-    Distributions.MvTDist(C.df, Σ)
-end
-
+U(C::TCopula) = isinf(C.df) ? Distributions.Normal() : Distributions.TDist(C.df)
+N(C::TCopula) = isinf(C.df) ? Distributions.MvNormal : (Σ -> Distributions.MvTDist(C.df, Σ))
+@inline _gaussian_limit(C::TCopula) = GaussianCopula(copy(C.Σ))
 function _cdf(C::TCopula{d}, u) where d
+    isinf(C.df) && return _cdf(_gaussian_limit(C), u)
     T = promote_type(eltype(C), eltype(u))
     T <: Union{Float32,Float64} ||
         return invoke(_cdf, Tuple{Copula,Any}, C, u)
@@ -89,6 +88,7 @@ function _student_rosenblatt_cache(C::TCopula{d}) where d
 end
 
 function rosenblatt(C::TCopula{d}, u::AbstractMatrix{<:Real}) where {d}
+    isinf(C.df) && return rosenblatt(_gaussian_limit(C), u)
     size(u, 1) == d || throw(ArgumentError("Dimension mismatch between copula and input matrix"))
     ν = C.df
     Tu = Distributions.TDist(ν)
@@ -112,6 +112,7 @@ function rosenblatt(C::TCopula{d}, u::AbstractMatrix{<:Real}) where {d}
 end
 
 function inverse_rosenblatt(C::TCopula{d}, s::AbstractMatrix{<:Real}) where {d}
+    isinf(C.df) && return inverse_rosenblatt(_gaussian_limit(C), s)
     size(s, 1) == d || throw(ArgumentError("Dimension mismatch between copula and input matrix"))
     ν = C.df
     Tu = Distributions.TDist(ν)
@@ -173,6 +174,7 @@ end
 
 # Conditioning colocated
 function distortion(C::TCopula{D}, js::NTuple{p,Int}, uⱼₛ::NTuple{p,Float64}, i::Int) where {p,D}
+    isinf(C.df) && return distortion(_gaussian_limit(C), js, uⱼₛ, i,)
     ν = C.df
     Σ = C.Σ; jst = js; ist = Tuple(setdiff(1:D, jst)); @assert i in ist
     Jv = collect(jst); zJ = Distributions.quantile.(Distributions.TDist(ν), collect(uⱼₛ))
@@ -205,6 +207,10 @@ end
 
 function _conditional_components(C::TCopula{D}, js::NTuple{p,Int},
                                  uⱼₛ::NTuple{p,Float64}, is) where {D,p}
+    if isinf(C.df)
+        Gcond, distortions = _conditional_components(_gaussian_limit(C), js, uⱼₛ, is,)
+        return TCopula(Inf, copy(Gcond.Σ),), distortions
+    end
     ν = C.df
     J = collect(Int, js)
     I = collect(Int, is)
@@ -242,8 +248,107 @@ function _rebound_params(::Type{<:TCopula}, d::Int, α::AbstractVector{T}) where
     Σ = _rebound_corr_params(d, @view α[2:end])
     return (; ν = ν, Σ = Σ)
 end
-
-
+function _t_copula_loglik_factor(ν, L, Z,)
+    d, n = size(Z)
+    Ltri = LinearAlgebra.LowerTriangular(L)
+    # R = L L', hence
+    # qᵢ = zᵢ' R⁻¹ zᵢ = ||L⁻¹ zᵢ||².
+    Y = Ltri \ Z
+    q = vec(sum(abs2, Y; dims=1))
+    logdetR = 2 * sum(log, LinearAlgebra.diag(L))
+    logconstant = SpecialFunctions.loggamma((ν + d) / 2) + (d - 1) * SpecialFunctions.loggamma(ν / 2) - d * SpecialFunctions.loggamma((ν + 1) / 2)
+    joint = n * logconstant - (n / 2) * logdetR - (ν + d) / 2 * sum(log1p.(q ./ ν))
+    marginals = (ν + 1) / 2 * sum(log1p.(abs2.(Z) ./ ν))
+    return joint + marginals
+end
+function _fit_t_corr_given_nu(U, ν,)
+    d, n = size(U)
+    # For fixed ν, Student scores are constant throughout
+    # the correlation optimization.
+    Z = Distributions.quantile.(Distributions.TDist(ν), U)
+    R₀ = _score_corr_start(Z)
+    α₀ = _unbound_corr_params(d, R₀)
+    objective = α -> begin
+        L = _rebound_corr_factor(d, α)
+        Ltri = LinearAlgebra.LowerTriangular(L)
+        Y = Ltri \ Z
+        q = vec(sum(abs2, Y; dims=1))
+        logdetR = 2 * sum(log, LinearAlgebra.diag(L))
+        return (n/2) * logdetR + (ν + d) / 2 * sum(log1p.(q ./ ν))
+    end
+    res = try
+        Optim.optimize(objective, α₀, Optim.LBFGS(); autodiff=ADTypes.AutoForwardDiff(),)
+    catch
+        Optim.optimize(objective, α₀, Optim.NelderMead(),)
+    end
+    α̂ = Optim.minimizer(res)
+    L̂ = _rebound_corr_factor(d, α̂)
+    R̂ = L̂ * L̂'
+    R̂ = (R̂ + R̂') / 2
+    ll = _t_copula_loglik_factor(ν, L̂, Z,)
+    return (ν=ν, Σ=R̂, loglikelihood=ll, result=res,)
+end
+function _t_profile_upper(loss; upper0 = 0.5, max_expand = 12,)
+    upper = upper0
+    fmid = loss(upper / 2)
+    fupper = loss(upper)
+    expansions = 0
+    while isfinite(fupper) && (!isfinite(fmid) || fupper < fmid)
+        expansions += 1
+        expansions > max_expand && error("Could not bracket the Student profile likelihood",)
+        upper *= 2
+        fmid = fupper
+        fupper = loss(upper)
+    end
+    return upper, expansions
+end
+function _fit(::Type{<:TCopula}, U, ::Val{:mle},)
+    # λ = 1 / ν.  The endpoint λ = 0 is the Gaussian limit ν = Inf.
+    G, gaussian_details = _fit(GaussianCopula, U, Val(:mle))
+    Σ_gaussian = Distributions.params(G).Σ
+    ll_gaussian = Distributions.loglikelihood(G, U)
+    profile_evaluations = Ref(0)
+    profile_loss = λ -> begin
+        profile_evaluations[] += 1
+        if iszero(λ) return -ll_gaussian end
+        ν = inv(λ)
+        try
+            fitν = _fit_t_corr_given_nu(U, ν)
+            return -fitν.loglikelihood
+        catch
+            return Inf
+        end
+    end
+    upper, expansions = _t_profile_upper(profile_loss)
+    resλ = Optim.optimize(profile_loss, zero(upper), upper, Optim.Brent(),)
+    λ̂ = Optim.minimizer(resλ)
+    ν̂_finite = inv(λ̂)
+    finite = _fit_t_corr_given_nu(U, ν̂_finite,)
+    ll_finite = finite.loglikelihood
+    # Numerical tolerance only for deciding whether the profile maximum
+    # is distinguishable from the exact Gaussian endpoint.
+    Tll = typeof(float(ll_gaussian))
+    ll_tol = 100 * eps(Tll) * max(one(Tll), abs(ll_gaussian))
+    use_gaussian_limit = ll_gaussian >= ll_finite - ll_tol
+    if use_gaussian_limit
+        ν̂ = Inf
+        Σ̂ = copy(Σ_gaussian)
+        converged = Optim.converged(resλ) && gaussian_details.converged
+        correlation_iterations = gaussian_details.iterations
+        correlation_optimizer = gaussian_details.optimizer
+    else
+        ν̂ = ν̂_finite
+        Σ̂ = finite.Σ
+        converged = Optim.converged(resλ) && Optim.converged(finite.result)
+        correlation_iterations = Optim.iterations(finite.result)
+        correlation_optimizer = Optim.summary(finite.result)
+    end
+    C = TCopula(ν̂, Σ̂)
+    θ̂ = (; ν = ν̂, Σ = Σ̂)
+    return C, (;θ̂, optimizer = "Brent(profile λ=1/ν)", correlation_optimizer, converged, iterations = Optim.iterations(resλ),
+    profile_evaluations = profile_evaluations[], correlation_iterations, profile_upper = upper,
+    profile_expansions = expansions, gaussian_limit = use_gaussian_limit,)
+end
 function _fit(::Type{<:TCopula}, U, ::Val{:itau_irho})
     size(U, 1) == 2 || throw(ArgumentError("Student rank matching is only defined in dimension 2"))
     τ̂ = StatsBase.corkendall(U')[1, 2]

--- a/test/correctness/elliptical.jl
+++ b/test/correctness/elliptical.jl
@@ -65,3 +65,19 @@ end
     @test logpdf(C64, Float32[0.4, 0.6]) isa Float64
     @test logpdf(C64, Float32[0.4, 0.6]) ≈ logpdf(C64, [0.4, 0.6]) rtol=1e-6
 end
+
+@testset "TCopula Gaussian limit at ν = Inf" begin
+    Σ = [1.0  0.6  0.3; 0.6  1.0  0.5; 0.3  0.5  1.0]
+    T∞ = TCopula(Inf, copy(Σ))
+    G = GaussianCopula(copy(Σ))
+    u = [0.2, 0.4, 0.7]
+    @test pdf(T∞, u) ≈ pdf(G, u) rtol=1e-13
+    # Both CDF evaluations are numerical.
+    @test cdf(T∞, u) ≈ cdf(G, u) atol=5e-5
+    U = rand(StableRNG(479), G, 20)
+    RT = rosenblatt(T∞, U)
+    RG = rosenblatt(G, U)
+    @test RT ≈ RG atol=1e-13
+    @test inverse_rosenblatt(T∞, RT) ≈ U atol=1e-12
+    @test loglikelihood(T∞, U) ≈ loglikelihood(G, U) atol=1e-12
+end

--- a/test/correctness/elliptical.jl
+++ b/test/correctness/elliptical.jl
@@ -73,7 +73,7 @@ end
     u = [0.2, 0.4, 0.7]
     @test pdf(T∞, u) ≈ pdf(G, u) rtol=1e-13
     # Both CDF evaluations are numerical.
-    @test cdf(T∞, u) ≈ cdf(G, u) atol=5e-5
+    @test cdf(T∞, u) ≈ cdf(G, u) atol=1e-12
     U = rand(StableRNG(479), G, 20)
     RT = rosenblatt(T∞, U)
     RG = rosenblatt(G, U)

--- a/test/operations/fitting.jl
+++ b/test/operations/fitting.jl
@@ -40,6 +40,67 @@ end
     @test Copulas.ρ(fitted) ≈ StatsBase.corspearman(U')[1, 2] atol=2e-3
 end
 
+@testset "Gaussian MLE maximizes the copula likelihood" begin
+    # Regression test for #477.
+    z1 = [
+        -0.789121, -0.167787,  1.487925,  0.393974,  1.120231,
+         0.777104, -0.436464,  0.741952, -0.116595, -0.122389,
+         0.297167, -1.325930,  1.392166, -0.471090,  1.200269,
+         0.336321,  1.732033, -0.459969, -0.111795,  0.537769,
+    ]
+    z2 = [
+        -2.702032,  0.644028,  2.185593,  1.223794,  1.214885,
+         0.142574,  0.963670,  1.345007,  0.234323, -0.156080,
+        -0.313183, -1.993197,  1.822312, -2.507589,  0.129987,
+         0.232541,  1.625898,  1.431677,  0.837426, -0.122637,
+    ]
+    N01 = Normal()
+    U = Matrix{Float64}(undef, 2, length(z1))
+    U[1, :] .= cdf.(N01, z1)
+    U[2, :] .= cdf.(N01, z2)
+    fitted = fit(GaussianCopula, U; method=:mle, vcov=false, derived_measures=false,)
+    @test fitted isa GaussianCopula{2}
+    @test fitted.Σ[1, 2] ≈ 0.5561662371678145 atol=1e-8
+    @test loglikelihood(fitted, U) ≈ 5.140188516707351 atol=1e-10
+end
+
+@testset "Student MLE profiles degrees of freedom" begin
+    d = 3
+    ρ = 0.55
+    Σ = [ρ^abs(i - j) for i in 1:d, j in 1:d]
+    source = TCopula(4.0, copy(Σ))
+    U = rand(StableRNG(477), source, 1_000)
+    model = fit(CopulaModel, TCopula, U; method=:mle, vcov=false, derived_measures=false,)
+    fitted = fitteddistribution(model)
+    θ = params(fitted)
+    @test model.converged
+    @test fitted isa TCopula{3}
+    @test θ.ν > 0
+    @test isfinite(θ.ν)
+    @test LinearAlgebra.isposdef(LinearAlgebra.Symmetric(θ.Σ),)
+    @test maximum(abs.(LinearAlgebra.diag(θ.Σ) .- 1),) < 1e-12
+    # The Student profile contains the Gaussian copula as ν = Inf,
+    # so its fitted likelihood must not be worse than that endpoint.
+    gaussian = fit(GaussianCopula,U; method=:mle, vcov=false, derived_measures=false,)
+    @test loglikelihood(fitted, U) >= loglikelihood(gaussian, U) - 1e-8
+    @test model.method_details.profile_upper >= 0.5
+    @test model.method_details.profile_expansions >= 0
+end
+
+@testset "Student MLE can estimate ν below two" begin
+    d = 3
+    ρ = 0.5
+    Σ = [ρ^abs(i - j) for i in 1:d, j in 1:d]
+    source = TCopula(1.0, copy(Σ))
+    U = rand(StableRNG(478), source, 1_500)
+    model = fit(CopulaModel, TCopula, U; method=:mle, vcov=false, derived_measures=false,)
+    fitted = fitteddistribution(model)
+    @test model.converged
+    @test 0 < params(fitted).ν < 2
+    @test model.method_details.profile_expansions >= 1
+    @test model.method_details.profile_upper > 0.5
+end
+
 @testset "generic empirical EV estimators by dimension" begin
     checked = Set{Tuple{Method,Symbol,Symbol}}()
     selected = Set{Tuple{Method,Symbol,Symbol}}()
@@ -383,4 +444,20 @@ end
     end
 
     @test ForwardDiff.derivative(f, 2.0) ≈ 1.0
+end
+
+@testset "Gaussian copula multivariate MLE" begin
+    d = 5
+    n = 2_000
+    ρ = 0.6
+    R = [ρ^abs(i-j) for i in 1:d, j in 1:d]
+    source = GaussianCopula(R)
+    U = rand(StableRNG(477), source, n)
+    model = fit(CopulaModel, GaussianCopula, U; method=:mle, vcov=false, derived_measures=false,)
+    fitted = fitteddistribution(model)
+    R̂ = params(fitted).Σ
+    @test model.converged
+    @test LinearAlgebra.isposdef(LinearAlgebra.Symmetric(R̂))
+    @test maximum(abs.(diag(R̂) .- 1)) < 1e-12
+    @test maximum(abs.(R̂ - R)) < 0.05
 end


### PR DESCRIPTION
Fixes the Gaussian copula MLE reported in #477 by optimizing the copula likelihood directly.

Also adds a dedicated profile MLE for `TCopula`, using $\(\lambda = 1/\nu\)$, with the Gaussian limit handled explicitly at \$(\nu=\infty\).$

Includes regression tests for Gaussian MLE, Student MLE, $\(\nu<2\)$, and the Gaussian limit of `TCopula`.

All tests pass locally.

I think this #477 would be resolved after a quick review of this request.
